### PR TITLE
ui: move to template classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 build:
 	make schemas
-	gnome-extensions pack -f --podir=po --extra-source=convenience.js --extra-source=ui.js ./display-brightness-ddcutil@themightydeity.github.com/ --out-dir=./dist
+	gnome-extensions pack -f --podir=po --extra-source=ui --extra-source=convenience.js --extra-source=statusArea.js ./display-brightness-ddcutil@themightydeity.github.com/ --out-dir=./dist
 
 install:
 	gnome-extensions install --force ./dist/display-brightness-ddcutil@themightydeity.github.com.shell-extension.zip
 
 translation: 
-	xgettext --from-code=UTF-8 --output=display-brightness-ddcutil\@themightydeity.github.com/po/display-brightness-ddcutil.pot ./display-brightness-ddcutil\@themightydeity.github.com/*.js
+	xgettext --from-code=UTF-8 --output=display-brightness-ddcutil\@themightydeity.github.com/po/display-brightness-ddcutil.pot ./display-brightness-ddcutil\@themightydeity.github.com/ui/prefs.ui ./display-brightness-ddcutil\@themightydeity.github.com/extension.js
 
 schemas:
 	glib-compile-schemas ./display-brightness-ddcutil@themightydeity.github.com/schemas

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ sudo cp /usr/share/ddcutil/data/45-ddcutil-i2c.rules /etc/udev/rules.d
 
   ```
 
-  sudo usermod your-user-name -aG i2c
-
   sudo groupadd --system i2c
+
+  sudo usermod your-user-name -aG i2c
 
   ```
 
@@ -85,4 +85,3 @@ As a workaround I changed this extension to read cached info from a file, when i
 ```
 ddcutil --brief detect > $XDG_CACHE_HOME/ddcutil_detect
 ```
-

--- a/display-brightness-ddcutil@themightydeity.github.com/convenience.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/convenience.js
@@ -31,71 +31,8 @@ const {GLib, Gio} = imports.gi;
 const Config = imports.misc.config;
 const ExtensionUtils = imports.misc.extensionUtils;
 
-
-
 var SHOW_ALL_SLIDER = 'show-all-slider';
 var SHOW_VALUE_LABEL = 'show-value-label';
-
-/**
- * initTranslations:
- * @domain: (optional): the gettext domain to use
- *
- * Initialize Gettext to load translations from extensionsdir/locale.
- * If @domain is not provided, it will be taken from metadata['gettext-domain']
- */
-function initTranslations(domain) {
-    let extension = ExtensionUtils.getCurrentExtension();
-
-    domain = domain || extension.metadata['gettext-domain'];
-
-    // check if this extension was built with "make zip-file", and thus
-    // has the locale files in a subfolder
-    // otherwise assume that extension has been installed in the
-    // same prefix as gnome-shell
-    let localeDir = extension.dir.get_child('locale');
-    if (localeDir.query_exists(null))
-        Gettext.bindtextdomain(domain, localeDir.get_path());
-    else
-        Gettext.bindtextdomain(domain, Config.LOCALEDIR);
-}
-
-/**
- * getSettings:
- * @schema: (optional): the GSettings schema id
- *
- * Builds and return a GSettings schema for @schema, using schema files
- * in extensionsdir/schemas. If @schema is not provided, it is taken from
- * metadata['settings-schema'].
- */
-function getSettings(schema) {
-    let extension = ExtensionUtils.getCurrentExtension();
-
-    schema = schema || extension.metadata['settings-schema'];
-
-    const GioSSS = Gio.SettingsSchemaSource;
-
-    // check if this extension was built with "make zip-file", and thus
-    // has the schema files in a subfolder
-    // otherwise assume that extension has been installed in the
-    // same prefix as gnome-shell (and therefore schemas are available
-    // in the standard folders)
-    let schemaDir = extension.dir.get_child('schemas');
-    let schemaSource;
-    if (schemaDir.query_exists(null))
-        schemaSource = GioSSS.new_from_directory(schemaDir.get_path(),
-                                                 GioSSS.get_default(),
-                                                 false);
-    else
-        schemaSource = GioSSS.get_default();
-
-    let schemaObj = schemaSource.lookup(schema, true);
-    if (!schemaObj)
-        throw new Error('Schema ' + schema + ' could not be found for extension '
-                        + extension.metadata.uuid + '. Please check your installation.');
-
-    return new Gio.Settings({ settings_schema: schemaObj });
-}
-
 
 //timer
 /**
@@ -121,15 +58,6 @@ function clearTimeout(id) {
 };
 
 /* extra for this brightness extension added by github.com/themightydeity */
-
-function spawnCommandAndRead(command_line) {
-  try {
-      let stuff = ByteArray.toString(GLib.spawn_command_line_sync(command_line)[1]);
-      return stuff;
-  } catch (err) {
-      return null;
-  }
-}
 
 function spawnWithCallback(argv, callback) {
   let proc = Gio.Subprocess.new(argv, Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE);

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -22,18 +22,16 @@ const {GLib, Gio, St} = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
-const Gettext = imports.gettext;
 
 const Convenience = Me.imports.convenience;
 
-const Domain = Gettext.domain(Me.metadata['gettext-domain']);
-const _ = Domain.gettext;
+const _ = ExtensionUtils.gettext;
 
 //for ui stuff of this extension
 const { 
     StatusAreaBrightnessMenu, 
     SingleMonitorMenuItem, 
-    SingleMonitorSliderAndValue } = Me.imports.ui;
+    SingleMonitorSliderAndValue } = Me.imports.statusArea;
 
 const PopupMenu = imports.ui.popupMenu;
 
@@ -75,7 +73,7 @@ class DDCUtilBrightnessControlExtension {
 }
 
 function init() {
-    ExtensionUtils.initTranslations(Me.metadata['gettext-domain']);
+    ExtensionUtils.initTranslations();
 
     return new DDCUtilBrightnessControlExtension();
 }
@@ -97,7 +95,6 @@ function BrightnessControl(set) {
 
             addAllDisplaysToPanel();
         }
-        
 
     } else if (set == "disable") {
         /* disconnect all signals */
@@ -264,8 +261,6 @@ function getCachedDisplayInfoAsync(panel) {
     Convenience.spawnWithCallback(["cat", ddcutil_detect_cache_file], function (stdout) { });
 }
 
-
-
 function onSettingsChange(){
     brightnessLog("Settings change detected, reloading widgets")
     reloadMenuWidgets()
@@ -300,7 +295,6 @@ function connectSettingsSignals() {
     }
 }
 
-
 let monitorSignals = {}
 
 function connectMonitorChangeSignals() {
@@ -328,7 +322,6 @@ function addAllDisplaysToPanel(){
         brightnessLog(err);
     }
 }
-
 
 function openPrefs() {
     if (typeof ExtensionUtils.openPrefs === 'function') {

--- a/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-31 00:41+0200\n"
+"POT-Creation-Date: 2021-12-28 15:58+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,30 +17,30 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:95
-msgid "Initializing"
-msgstr ""
-
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:132
-msgid "Settings"
-msgstr ""
-
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:136
-msgid "Reload"
-msgstr ""
-
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:148
-msgid "All"
-msgstr ""
-
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:238
-msgid "Monitor:"
-msgstr ""
-
-#: display-brightness-ddcutil@themightydeity.github.com/prefs.js:34
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:46
 msgid "Enable \"All\" Slider"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/prefs.js:49
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:80
 msgid "Show Value Label"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:93
+msgid "Initializing"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:129
+msgid "Settings"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:133
+msgid "Reload"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:145
+msgid "All"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:235
+msgid "Monitor:"
 msgstr ""

--- a/display-brightness-ddcutil@themightydeity.github.com/po/es.po
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/es.po
@@ -7,41 +7,41 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-31 00:04+0200\n"
-"PO-Revision-Date: 2021-07-31 13:00+0200\n"
+"POT-Creation-Date: 2021-12-28 15:58+0100\n"
+"PO-Revision-Date: 2021-12-28 15:58+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.0.1\n"
 
-#: extension.js:94
-msgid "Initializing"
-msgstr "Inicializando"
-
-#: extension.js:131
-msgid "Settings"
-msgstr "Configuración"
-
-#: extension.js:135
-msgid "Reload"
-msgstr "Recargar"
-
-#: extension.js:147
-msgid "All"
-msgstr "Todos"
-
-#: extension.js:237
-msgid "Monitor:"
-msgstr "Monitor:"
-
-#: prefs.js:28
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:46
 msgid "Enable \"All\" Slider"
 msgstr "Activar el control para \"Todos\""
 
-#: prefs.js:43
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:80
 msgid "Show Value Label"
 msgstr "Mostrar la etiqueta del valor"
+
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:93
+msgid "Initializing"
+msgstr "Inicializando"
+
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:129
+msgid "Settings"
+msgstr "Configuración"
+
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:133
+msgid "Reload"
+msgstr "Recargar"
+
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:145
+msgid "All"
+msgstr "Todos"
+
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:235
+msgid "Monitor:"
+msgstr "Monitor:"

--- a/display-brightness-ddcutil@themightydeity.github.com/prefs.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/prefs.js
@@ -1,65 +1,45 @@
-const GObject = imports.gi.GObject;
-const Gtk = imports.gi.Gtk;
-const Gio = imports.gi.Gio;
+const {Gio, GObject, Gtk} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
-const Gettext = imports.gettext;
 const Convenience = Me.imports.convenience;
-
-const Domain = Gettext.domain(Me.metadata['gettext-domain']);
-const _ = Domain.gettext;
 
 const {SHOW_ALL_SLIDER, SHOW_VALUE_LABEL} = Me.imports.convenience;
 
+const PrefsWidget = GObject.registerClass({
+    GTypeName: 'PrefsWidget',
+    Template: Me.dir.get_child('./ui/prefs.ui').get_uri(),
+    InternalChildren: [
+        'show_all_slider_switch',
+        'show_value_label_switch',
+    ],
+}, class PrefsWidget extends Gtk.Box {
+
+    _init(params = {}) {
+      super._init(params);
+      this.settings = ExtensionUtils.getSettings();
+
+      this.settings.bind(
+          'show-all-slider',
+          this._show_all_slider_switch,
+          'active',
+          Gio.SettingsBindFlags.DEFAULT
+      );
+
+      this.settings.bind(
+          'show-value-label',
+          this._show_value_label_switch,
+          'active',
+          Gio.SettingsBindFlags.DEFAULT
+      );
+    }
+
+  }
+);
 
 function init() {
-  ExtensionUtils.initTranslations(Me.metadata['gettext-domain']);
+  ExtensionUtils.initTranslations();
 }
 
 function buildPrefsWidget() {
-  let widget = new MyPrefsWidget();
-  return widget;
+  return new PrefsWidget();
 }
-
-const MyPrefsWidget = GObject.registerClass(
-  class MyPrefsWidget extends Gtk.Box {
-
-    _init(params) {
-      super._init(params);
-      this._settings = Convenience.getSettings();
-      this.set_orientation(Gtk.Orientation.VERTICAL);
-
-      let showAllSliderBox = new Gtk.Box({marginStart:7, marginEnd:7, marginBottom:5, marginTop:5});
-
-      const showAllSliderLabel = new Gtk.Label({label:_("Enable \"All\" Slider"),
-      xalign: 0, marginEnd:7});
-
-      const showAllSliderSwitch = new Gtk.Switch({active: this._settings.get_boolean(SHOW_ALL_SLIDER)});
-      showAllSliderSwitch.connect('notify::active', button => {
-          this._settings.set_boolean(SHOW_ALL_SLIDER, button.active);
-      });
-
-      showAllSliderBox.append(showAllSliderLabel);
-      showAllSliderBox.append(showAllSliderSwitch);
-
-
-
-      let showValueLabelBox = new Gtk.Box({marginStart:7, marginEnd:7, marginBottom:5, marginTop:5});
-
-      const showValueLabelLabel = new Gtk.Label({label:_("Show Value Label"),
-      xalign: 0, marginEnd:7});
-
-      const showValueLabelSwitch = new Gtk.Switch({active: this._settings.get_boolean(SHOW_VALUE_LABEL)});
-      showValueLabelSwitch.connect('notify::active', button => {
-          this._settings.set_boolean(SHOW_VALUE_LABEL, button.active);
-      });
-
-      showValueLabelBox.append(showValueLabelLabel);
-      showValueLabelBox.append(showValueLabelSwitch);
-
-      this.append(showValueLabelBox);
-      this.append(showAllSliderBox);
-
-    }
-
-  });

--- a/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
+++ b/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schemalist>
+<schemalist gettext-domain="display-brightness-ddcutil">
   <schema id="org.gnome.shell.extensions.display-brightness-ddcutil" path="/org/gnome/shell/extensions/display-brightness-ddcutil/">
     <key type="b" name="show-all-slider">
       <default>false</default>
@@ -11,5 +11,3 @@
     </key>
   </schema>
 </schemalist>
-  
-

--- a/display-brightness-ddcutil@themightydeity.github.com/statusArea.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/statusArea.js
@@ -16,7 +16,7 @@ const {SHOW_ALL_SLIDER, SHOW_VALUE_LABEL} = Me.imports.convenience;
 
 // for settings
 const Convenience = Me.imports.convenience;
-settings = Convenience.getSettings();
+settings = ExtensionUtils.getSettings();
 
 const brightnessIcon = 'display-brightness-symbolic';
 
@@ -35,7 +35,6 @@ var StatusAreaBrightnessMenu = GObject.registerClass({
         this.menu.addMenuItem(item);
     }
 });
-
 
 var SingleMonitorMenuItem = GObject.registerClass({
     GType: 'SingleMonitorMenuItem'

--- a/display-brightness-ddcutil@themightydeity.github.com/stylesheet.css
+++ b/display-brightness-ddcutil@themightydeity.github.com/stylesheet.css
@@ -1,1 +1,0 @@
-/* Add your custom extension styling here */

--- a/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface domain="display-brightness-ddcutil">
+  <requires lib="gtk" version="4.0"/>
+  <template class="PrefsWidget" parent="GtkBox">
+    <property name="orientation">vertical</property>
+    <property name="hexpand">1</property>
+    <child>
+      <object class="GtkScrolledWindow" id="items_container">
+        <property name="width-request">500</property>
+        <property name="height-request">500</property>
+        <property name="hscrollbar-policy">never</property>
+        <property name="vexpand">1</property>
+        <child>
+          <object class="GtkViewport" id="main_prefs">
+            <child>
+              <object class="GtkBox" id="main_prefs_box">
+                <property name="margin-start">36</property>
+                <property name="margin-end">36</property>
+                <property name="margin-top">36</property>
+                <property name="margin-bottom">36</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkFrame" id="main_frame">
+                    <property name="label-xalign">0</property>
+                    <child>
+                      <object class="GtkListBox" id="main_listbox">
+                        <property name="selection-mode">none</property>
+                        <child>
+                          <object class="GtkListBoxRow" id="show_all_slider_row">
+                              <child>
+                                <object class="GtkBox" id="show_all_slider_pref_box">
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">12</property>
+                                <property name="margin-top">12</property>
+                                <property name="margin-bottom">12</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkBox" id="show_all_slider_box">
+                                    <property name="spacing">32</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">Enable "All" Slider</property>
+                                        <property name="xalign">0</property>
+                                        <property name="hexpand">1</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSwitch" id="show_all_slider_switch">
+                                        <property name="valign">center</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkListBoxRow" id="show_value_label_row">
+                              <child>
+                                <object class="GtkBox" id="value_label_pref_box">
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">12</property>
+                                <property name="margin-top">12</property>
+                                <property name="margin-bottom">12</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkBox" id="show_value_label_box">
+                                    <property name="spacing">32</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">Show Value Label</property>
+                                        <property name="xalign">0</property>
+                                        <property name="hexpand">1</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSwitch" id="show_value_label_switch">
+                                        <property name="valign">center</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>


### PR DESCRIPTION
also update translation files and other minor cleanups

Source: https://gjs.guide/extensions/upgrading/gnome-shell-40.html#template-classes

Hopefully it will make things easier for those open feature requests, at least managing ui files, although prefs.ui could be split.

![imagen](https://user-images.githubusercontent.com/42654671/147557799-d0a3720d-2814-40a9-8cd5-7a516d7dcbed.png)