### PR TITLE
add scroll event to menu button

### DIFF
--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -152,6 +152,11 @@ function addDisplayToPanel(display) {
     }
     let displaySlider = new SingleMonitorSliderAndValue(display.name, display.current, onSliderChange);
     display.slider = displaySlider;
+
+    mainMenuButton.connect('scroll-event', (actor, event) => {
+        return display.slider.getSlider().emit('scroll-event', event);
+    });
+
     mainMenuButton.addMenuItem(displaySlider);
 }
 

--- a/display-brightness-ddcutil@themightydeity.github.com/statusArea.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/statusArea.js
@@ -76,6 +76,9 @@ var SingleMonitorSliderAndValue = class SingleMonitorSliderAndValue extends Popu
     changeValue(newValue) {
         this.ValueSlider.value = newValue / 100;
     }
+    getSlider() {
+        return this.ValueSlider;
+    }
     _SliderValueToBrightness(sliderValue) {
         return Math.floor(sliderValue * 100);
     }


### PR DESCRIPTION
Related https://github.com/daitj/gnome-display-brightness-ddcutil/issues/28

This is an attempt to try to add scrolling to the menu button although I could only get it to work for one monitor and it does not work for the "All" switch. As you can tell, it is far from an proper solution, it is more of a workaround as I'm not familiar with JS.

Feel free to use or change the code or close the PR 😄 