### PR TITLE
add button location preference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 gschemas.compiled
 dist
+display-brightness-ddcutil\@themightydeity.github.com/po/*.po~

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,31 @@
 all: build install
 
 build: schemas
-	gnome-extensions pack -f --podir=po --extra-source=ui --extra-source=convenience.js --extra-source=statusArea.js ./display-brightness-ddcutil@themightydeity.github.com/ --out-dir=./dist
+	gnome-extensions pack \
+		--force \
+		--extra-source=ui \
+		--extra-source=convenience.js \
+		--extra-source=headerbar.js \
+		--extra-source=indicator.js \
+		./display-brightness-ddcutil@themightydeity.github.com/ \
+		--out-dir=./dist
 
 install:
-	gnome-extensions install --force ./dist/display-brightness-ddcutil@themightydeity.github.com.shell-extension.zip
+	gnome-extensions install \
+		--force \
+		./dist/display-brightness-ddcutil@themightydeity.github.com.shell-extension.zip
 
-translation:
-	xgettext --from-code=UTF-8 --output=display-brightness-ddcutil\@themightydeity.github.com/po/display-brightness-ddcutil.pot ./display-brightness-ddcutil\@themightydeity.github.com/ui/prefs.ui ./display-brightness-ddcutil\@themightydeity.github.com/extension.js
+pot:
+	mkdir -p ./display-brightness-ddcutil@themightydeity.github.com/po
+	xgettext \
+		--from-code=UTF-8 \
+		--output=display-brightness-ddcutil\@themightydeity.github.com/po/display-brightness-ddcutil.pot \
+		./display-brightness-ddcutil\@themightydeity.github.com/ui/* ./display-brightness-ddcutil\@themightydeity.github.com/extension.js
+
+update-po:
+	for po_file in ./display-brightness-ddcutil@themightydeity.github.com/po/*.po; do \
+		msgmerge --update $$po_file display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot; \
+	done
 
 schemas:
 	glib-compile-schemas ./display-brightness-ddcutil@themightydeity.github.com/schemas

--- a/display-brightness-ddcutil@themightydeity.github.com/convenience.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/convenience.js
@@ -28,7 +28,6 @@
 const Gettext = imports.gettext;
 const { GLib, Gio } = imports.gi;
 
-const Config = imports.misc.config;
 const ExtensionUtils = imports.misc.extensionUtils;
 
 var SHOW_ALL_SLIDER = 'show-all-slider';

--- a/display-brightness-ddcutil@themightydeity.github.com/headerbar.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/headerbar.js
@@ -1,0 +1,25 @@
+const {Gio, GObject, Gtk} = imports.gi;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+
+const Headerbar = GObject.registerClass({
+    GTypeName: 'Headerbar',
+    Template: Me.dir.get_child('./ui/headerbar.ui').get_uri(),
+    InternalChildren: [
+        'reload_button'
+    ],
+}, class PrefsWidget extends Gtk.HeaderBar {
+
+    _init(params = {}) {
+        super._init(params);
+        this.settings = ExtensionUtils.getSettings();
+    }
+
+    // Triggers onReload function
+    onReloadButtonClicked(_button) {
+        this.settings.set_boolean('reload', true);
+        this.settings.set_boolean('reload', false);
+    }
+
+  }
+);

--- a/display-brightness-ddcutil@themightydeity.github.com/po/de.po
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/de.po
@@ -7,16 +7,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-31 00:41+0200\n"
+"POT-Creation-Date: 2022-01-04 03:25+0100\n"
 "PO-Revision-Date: 2022-01-02 02:00+0100\n"
 "Language-Team: \n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0\n"
-"Last-Translator: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: de\n"
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/headerbar.ui:8
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:148
+msgid "Reload"
+msgstr "Neu laden"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:27
 msgid "General"
@@ -30,39 +34,47 @@ msgstr "Gemeinsamen Schieberegler für alle Bildschirme anzeigen"
 msgid "Show Value Label"
 msgstr "Aktuellen Wert anzeigen"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:113
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:118
+msgid "Button Location"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:127
+msgid "Top Bar"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:128
+msgid "System Menu"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:148
 msgid "Keyboard Shortcuts"
 msgstr "Keyboard Shortcuts"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:142
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:177
 msgid "Increase Brightness"
 msgstr "Increase Brightness"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:152
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:186
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:187
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:221
 msgid "Apply"
 msgstr "Apply"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:176
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:211
 msgid "Decrease Brightness"
 msgstr "Decrease Brightness"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:95
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:105
 msgid "Initializing"
 msgstr "Initialisiere"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:133
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:144
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:137
-msgid "Reload"
-msgstr "Neu laden"
-
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:149
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:159
 msgid "All"
 msgstr "Alle"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:239
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:272
 msgid "Monitor:"
 msgstr "Bildschirm:"

--- a/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-01 19:42+0100\n"
+"POT-Creation-Date: 2022-01-04 03:31+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/headerbar.ui:8
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:148
+msgid "Reload"
+msgstr ""
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:27
 msgid "General"
@@ -29,39 +34,47 @@ msgstr ""
 msgid "Show Value Label"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:113
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:118
+msgid "Button Location"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:127
+msgid "Top Bar"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:128
+msgid "System Menu"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:148
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:142
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:177
 msgid "Increase Brightness"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:152
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:186
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:187
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:221
 msgid "Apply"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:176
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:211
 msgid "Decrease Brightness"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:95
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:105
 msgid "Initializing"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:133
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:144
 msgid "Settings"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:137
-msgid "Reload"
-msgstr ""
-
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:149
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:159
 msgid "All"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:239
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:272
 msgid "Monitor:"
 msgstr ""

--- a/display-brightness-ddcutil@themightydeity.github.com/po/es.po
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/es.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-01 19:42+0100\n"
-"PO-Revision-Date: 2022-01-01 19:42+0100\n"
+"POT-Creation-Date: 2022-01-04 03:25+0100\n"
+"PO-Revision-Date: 2022-01-02 15:21+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -17,6 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/headerbar.ui:8
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:148
+msgid "Reload"
+msgstr "Recargar"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:27
 msgid "General"
@@ -30,39 +35,47 @@ msgstr "Activar el control para \"Todos\""
 msgid "Show Value Label"
 msgstr "Mostrar la etiqueta del valor"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:113
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:118
+msgid "Button Location"
+msgstr "Ubicación del botón"
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:127
+msgid "Top Bar"
+msgstr "Barra superior"
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:128
+msgid "System Menu"
+msgstr "Menú del sistema"
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:148
 msgid "Keyboard Shortcuts"
 msgstr "Atajos del teclado"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:142
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:177
 msgid "Increase Brightness"
 msgstr "Aumentar brillo"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:152
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:186
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:187
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:221
 msgid "Apply"
 msgstr "Aplicar"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:176
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:211
 msgid "Decrease Brightness"
 msgstr "Reducir brillo"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:95
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:105
 msgid "Initializing"
 msgstr "Inicializando"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:133
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:144
 msgid "Settings"
 msgstr "Configuración"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:137
-msgid "Reload"
-msgstr "Recargar"
-
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:149
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:159
 msgid "All"
 msgstr "Todos"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:239
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:272
 msgid "Monitor:"
 msgstr "Monitor:"

--- a/display-brightness-ddcutil@themightydeity.github.com/prefs.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/prefs.js
@@ -3,7 +3,8 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 
-const {SHOW_ALL_SLIDER, SHOW_VALUE_LABEL} = Me.imports.convenience;
+const { SHOW_ALL_SLIDER, SHOW_VALUE_LABEL } = Me.imports.convenience;
+const { Headerbar } = Me.imports.headerbar;
 
 const PrefsWidget = GObject.registerClass({
     GTypeName: 'PrefsWidget',
@@ -11,6 +12,7 @@ const PrefsWidget = GObject.registerClass({
     InternalChildren: [
         'show_all_slider_switch',
         'show_value_label_switch',
+        'button_location_combo_button',
         'increase_shortcut_entry',
         'decrease_shortcut_entry',
         'increase_shortcut_button',
@@ -23,18 +25,25 @@ const PrefsWidget = GObject.registerClass({
       this.settings = ExtensionUtils.getSettings();
 
       this.settings.bind(
-          'show-all-slider',
+          SHOW_ALL_SLIDER,
           this._show_all_slider_switch,
           'active',
           Gio.SettingsBindFlags.DEFAULT
       );
 
       this.settings.bind(
-          'show-value-label',
+          SHOW_VALUE_LABEL,
           this._show_value_label_switch,
           'active',
           Gio.SettingsBindFlags.DEFAULT
       );
+
+      this.settings.bind(
+          'button-location',
+          this._button_location_combo_button,
+          'active-id',
+          Gio.SettingsBindFlags.DEFAULT
+        );
 
       this._increase_shortcut_entry.text = this.settings.get_strv('increase-brightness-shortcut')[0];
       this._decrease_shortcut_entry.text = this.settings.get_strv('decrease-brightness-shortcut')[0];
@@ -52,9 +61,15 @@ const PrefsWidget = GObject.registerClass({
 );
 
 function init() {
-  ExtensionUtils.initTranslations();
+    ExtensionUtils.initTranslations();
 }
 
 function buildPrefsWidget() {
-  return new PrefsWidget();
+    const preferences = new PrefsWidget();
+    preferences.connect('notify::root', () => {
+        const window = preferences.get_root();
+        const headerbar = new Headerbar();
+        window.set_titlebar(headerbar);
+    });
+    return preferences;
 }

--- a/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
+++ b/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
@@ -1,21 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="display-brightness-ddcutil">
   <schema id="org.gnome.shell.extensions.display-brightness-ddcutil" path="/org/gnome/shell/extensions/display-brightness-ddcutil/">
+    <key type="b" name="reload">
+      <default>false</default>
+      <summary>Reloads the Extension</summary>
+    </key>
     <key type="b" name="show-all-slider">
       <default>false</default>
-      <summary>Enables the All slider</summary>
+      <summary>Enables the All Slider</summary>
     </key>
     <key type="b" name="show-value-label">
       <default>false</default>
-      <summary>Show value label</summary>
+      <summary>Show Value Label</summary>
+    </key>
+    <key name="button-location" type="s">
+      <choices>
+        <choice value="panel"/>
+        <choice value="menu"/>
+      </choices>
+      <default>"panel"</default>
+      <summary>Brightness Button Location</summary>
     </key>
     <key type="as" name="increase-brightness-shortcut">
       <default><![CDATA[['<Ctrl><Alt><Shift>h']]]></default>
-      <summary>Ctrl+Alt+Shift+H</summary>
+      <summary>Increase Brightness Shortcut</summary>
     </key>
     <key type="as" name="decrease-brightness-shortcut">
       <default><![CDATA[['<Ctrl><Alt><Shift>g']]]></default>
-      <summary>Ctrl+Alt+Shift+G</summary>
+      <summary>Decrease Brightness Shortcut</summary>
     </key>
   </schema>
 </schemalist>

--- a/display-brightness-ddcutil@themightydeity.github.com/ui/headerbar.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/headerbar.ui
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface domain="display-brightness-ddcutil">
+  <requires lib="gtk" version="4.0"/>
+  <template class="Headerbar" parent="GtkHeaderBar">
+    <child type="start">
+      <object class="GtkButton" id="reload_button">
+        <property name="icon-name">view-refresh-symbolic</property>
+        <property name="tooltip-text" translatable="yes">Reload</property>
+        <signal name="clicked" handler="onReloadButtonClicked" swapped="no"/>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
@@ -100,6 +100,41 @@
                             </child>
                           </object>
                         </child>
+                        <child>
+                          <object class="GtkListBoxRow" id="button_location_row">
+                              <child>
+                                <object class="GtkBox" id="button_location_pref_box">
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">12</property>
+                                <property name="margin-top">12</property>
+                                <property name="margin-bottom">12</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkBox" id="button_location_box">
+                                    <property name="spacing">32</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">Button Location</property>
+                                        <property name="xalign">0</property>
+                                        <property name="hexpand">1</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="button_location_combo_button">
+                                        <property name="active-id">panel</property>
+                                        <items>
+                                          <item id="panel" translatable="yes">Top Bar</item>
+                                          <item id="menu" translatable="yes">System Menu</item>
+                                        </items>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
Known issues: when changing the button location several times in a short period of time, the shell freezes for a short period of time

Single monitor without value label:
![brightness-ddcutil-1](https://user-images.githubusercontent.com/42654671/147886916-6036fece-ad76-47ca-80ca-5dea21c15eca.png)

Single monitor + all slider + value label:
![brightness-ddcutil-2](https://user-images.githubusercontent.com/42654671/147886917-c1107f39-10bb-4d9b-9787-b7c1e1b63860.png)

Preferences (new button location row and reload button):
![brightness-ddcutil-3](https://user-images.githubusercontent.com/42654671/147886920-27923ab7-4957-4a06-b700-4f664eab07fe.png)

There are probably better and cleaner ways of implementing these changes 😅 

Partially fixes: https://github.com/daitj/gnome-display-brightness-ddcutil/issues/29 (when button location is set to system menu).