### PR TITLE
Add configs to system menu option

### DIFF
--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -100,7 +100,7 @@ function BrightnessControl(set) {
             Main.panel.addToStatusArea("DDCUtilBrightnessSlider", mainMenuButton, 0, "right");
         } else {
             brightnessLog("Adding to system menu");
-            mainMenuButton = new SystemMenuBrightnessMenu();
+            mainMenuButton = new SystemMenuBrightnessMenu(settings);
             AggregateMenu._indicators.add_child(mainMenuButton);
             AggregateMenu.menu.addMenuItem(mainMenuButton.menu, 3);
         }
@@ -365,8 +365,7 @@ function onMonitorChange() {
     }
     monitorChangeTimeout = Convenience.setTimeout(function () {
         monitorChangeTimeout = null;
-        BrightnessControl("disable");
-        BrightnessControl("enable");
+        reloadExtension();
     }, 5000);
 
 }
@@ -379,7 +378,8 @@ function connectSettingsSignals(settings) {
             onSettingsChange(settings)
         }),
         reload: settings.connect('changed::reload', reloadExtension),
-        indicator: settings.connect('changed::button-location', reloadExtension)
+        indicator: settings.connect('changed::button-location', reloadExtension),
+        hide_system_indicator: settings.connect('changed::hide-system-indicator', reloadExtension)
     }
 }
 

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -102,7 +102,7 @@ function BrightnessControl(set) {
             brightnessLog("Adding to system menu");
             mainMenuButton = new SystemMenuBrightnessMenu(settings);
             AggregateMenu._indicators.add_child(mainMenuButton);
-            AggregateMenu.menu.addMenuItem(mainMenuButton.menu, 3);
+            AggregateMenu.menu.addMenuItem(mainMenuButton.menu, settings.get_double('position-system-menu'));
         }
         if (mainMenuButton !== null) {
             /* connect all signals */
@@ -379,7 +379,8 @@ function connectSettingsSignals(settings) {
         }),
         reload: settings.connect('changed::reload', reloadExtension),
         indicator: settings.connect('changed::button-location', reloadExtension),
-        hide_system_indicator: settings.connect('changed::hide-system-indicator', reloadExtension)
+        hide_system_indicator: settings.connect('changed::hide-system-indicator', reloadExtension),
+        position_system_menu: settings.connect('changed::position-system-menu', reloadExtension)
     }
 }
 

--- a/display-brightness-ddcutil@themightydeity.github.com/indicator.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/indicator.js
@@ -84,12 +84,12 @@ var SystemMenuBrightnessMenu = GObject.registerClass({
     GType: 'SystemMenuBrightnessMenu',
     Signals: { 'value-up': {}, 'value-down': {} },
 }, class SystemMenuBrightnessMenu extends PanelMenu.SystemIndicator {
-    _init() {
+    _init(settings) {
         super._init();
+        this._valueSliders = [];
         this._indicator = this._addIndicator();
         this._indicator.icon_name = 'display-brightness-symbolic';
-        this._valueSliders = [];
-
+        this._indicator.visible = !settings.get_boolean('hide-system-indicator');
         this.connect('scroll-event', valueSliderScrollEvent);
         this.connect('value-up', (actor, event) => {
             valueSliderMoveEvent(actor, SLIDER_SCROLL_STEP)

--- a/display-brightness-ddcutil@themightydeity.github.com/po/de.po
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-07 00:24+0200\n"
+"POT-Creation-Date: 2022-01-07 13:26+0100\n"
 "PO-Revision-Date: 2022-01-05 12:42+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -52,36 +52,41 @@ msgstr "Obere Leiste"
 msgid "System Menu"
 msgstr "System-Menü"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:188
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:191
 msgid "Hide System Indicator"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:216
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:222
+#, fuzzy
+msgid "Position in System Menu"
+msgstr "System-Menü"
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:255
 msgid "Keyboard Shortcuts"
 msgstr "Tastaturkurzbefehle"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:245
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:284
 msgid "Increase Brightness"
 msgstr "Helligkeit erhöhen"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:255
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:289
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:294
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:328
 msgid "Apply"
 msgstr "Anwenden"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:279
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:318
 msgid "Decrease Brightness"
 msgstr "Helligkeit verringern"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:308
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:347
 msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:337
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:376
 msgid "Allow zero brightness"
 msgstr "Vollständige Abdunkelung erlauben"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:368
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:407
 msgid "Disable display state check"
 msgstr "Status-Überprüfung deaktivieren"
 
@@ -100,7 +105,3 @@ msgstr "Alle"
 #: display-brightness-ddcutil@themightydeity.github.com/extension.js:317
 msgid "Monitor:"
 msgstr "Bildschirm:"
-
-#, fuzzy
-#~ msgid "Position in System Menu"
-#~ msgstr "System-Menü"

--- a/display-brightness-ddcutil@themightydeity.github.com/po/de.po
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/de.po
@@ -28,6 +28,7 @@ msgid "General"
 msgstr "Allgemein"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:56
+#, fuzzy
 msgid "Enable \"All\" Slider"
 msgstr "Gemeinsamen Schieberegler anzeigen"
 
@@ -43,40 +44,44 @@ msgstr "Bildschirmname anzeigen"
 msgid "Button Location"
 msgstr "Position der Schaltfläche"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:158
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:159
 msgid "Top Bar"
 msgstr "Obere Leiste"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:159
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:160
 msgid "System Menu"
 msgstr "System-Menü"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:179
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:188
+msgid "Hide System Indicator"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:216
 msgid "Keyboard Shortcuts"
 msgstr "Tastaturkurzbefehle"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:208
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:245
 msgid "Increase Brightness"
 msgstr "Helligkeit erhöhen"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:218
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:252
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:255
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:289
 msgid "Apply"
 msgstr "Anwenden"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:242
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:279
 msgid "Decrease Brightness"
 msgstr "Helligkeit verringern"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:271
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:308
 msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:300
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:337
 msgid "Allow zero brightness"
 msgstr "Vollständige Abdunkelung erlauben"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:331
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:368
 msgid "Disable display state check"
 msgstr "Status-Überprüfung deaktivieren"
 
@@ -95,3 +100,7 @@ msgstr "Alle"
 #: display-brightness-ddcutil@themightydeity.github.com/extension.js:317
 msgid "Monitor:"
 msgstr "Bildschirm:"
+
+#, fuzzy
+#~ msgid "Position in System Menu"
+#~ msgstr "System-Menü"

--- a/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
@@ -42,40 +42,44 @@ msgstr ""
 msgid "Button Location"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:158
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:159
 msgid "Top Bar"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:159
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:160
 msgid "System Menu"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:179
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:188
+msgid "Hide System Indicator"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:216
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:208
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:245
 msgid "Increase Brightness"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:218
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:252
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:255
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:289
 msgid "Apply"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:242
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:279
 msgid "Decrease Brightness"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:271
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:308
 msgid "Advanced Settings"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:300
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:337
 msgid "Allow zero brightness"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:331
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:368
 msgid "Disable display state check"
 msgstr ""
 

--- a/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-07 00:24+0200\n"
+"POT-Creation-Date: 2022-01-07 13:45+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,36 +50,40 @@ msgstr ""
 msgid "System Menu"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:188
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:191
 msgid "Hide System Indicator"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:216
-msgid "Keyboard Shortcuts"
-msgstr ""
-
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:245
-msgid "Increase Brightness"
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:222
+msgid "Position in System Menu"
 msgstr ""
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:255
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:289
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:284
+msgid "Increase Brightness"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:294
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:328
 msgid "Apply"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:279
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:318
 msgid "Decrease Brightness"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:308
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:347
 msgid "Advanced Settings"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:337
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:376
 msgid "Allow zero brightness"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:368
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:407
 msgid "Disable display state check"
 msgstr ""
 

--- a/display-brightness-ddcutil@themightydeity.github.com/po/es.po
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/es.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-07 00:24+0200\n"
-"PO-Revision-Date: 2022-01-04 20:16+0100\n"
+"POT-Creation-Date: 2022-01-07 13:26+0100\n"
+"PO-Revision-Date: 2022-01-06 23:37+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -51,36 +51,40 @@ msgstr "Barra superior"
 msgid "System Menu"
 msgstr "Menú del sistema"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:188
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:191
 msgid "Hide System Indicator"
 msgstr "Ocultar el indicador del sistema"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:216
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:222
+msgid "Position in System Menu"
+msgstr "Posición en el menú del sistema"
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:255
 msgid "Keyboard Shortcuts"
 msgstr "Atajos del teclado"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:245
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:284
 msgid "Increase Brightness"
 msgstr "Aumentar brillo"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:255
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:289
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:294
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:328
 msgid "Apply"
 msgstr "Aplicar"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:279
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:318
 msgid "Decrease Brightness"
 msgstr "Reducir brillo"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:308
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:347
 msgid "Advanced Settings"
 msgstr "Configuración avanzada"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:337
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:376
 msgid "Allow zero brightness"
 msgstr "Permitir brillo cero"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:368
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:407
 msgid "Disable display state check"
 msgstr "Desactivar la comprobación del estado de la pantalla"
 

--- a/display-brightness-ddcutil@themightydeity.github.com/po/es.po
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/es.po
@@ -43,40 +43,44 @@ msgstr "Mostrar nombre de la pantalla"
 msgid "Button Location"
 msgstr "Ubicación del botón"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:158
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:159
 msgid "Top Bar"
 msgstr "Barra superior"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:159
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:160
 msgid "System Menu"
 msgstr "Menú del sistema"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:179
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:188
+msgid "Hide System Indicator"
+msgstr "Ocultar el indicador del sistema"
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:216
 msgid "Keyboard Shortcuts"
 msgstr "Atajos del teclado"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:208
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:245
 msgid "Increase Brightness"
 msgstr "Aumentar brillo"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:218
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:252
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:255
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:289
 msgid "Apply"
 msgstr "Aplicar"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:242
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:279
 msgid "Decrease Brightness"
 msgstr "Reducir brillo"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:271
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:308
 msgid "Advanced Settings"
 msgstr "Configuración avanzada"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:300
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:337
 msgid "Allow zero brightness"
 msgstr "Permitir brillo cero"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:331
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:368
 msgid "Disable display state check"
 msgstr "Desactivar la comprobación del estado de la pantalla"
 

--- a/display-brightness-ddcutil@themightydeity.github.com/prefs.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/prefs.js
@@ -13,6 +13,8 @@ const PrefsWidget = GObject.registerClass({
         'show_value_label_switch',
         'show_display_name_switch',
         'button_location_combo_button',
+        'system_menu_revealer',
+        'hide_system_indicator_switch',
         'increase_shortcut_entry',
         'decrease_shortcut_entry',
         'increase_shortcut_button',
@@ -55,6 +57,13 @@ const PrefsWidget = GObject.registerClass({
         );
 
         this.settings.bind(
+            'hide-system-indicator',
+            this._hide_system_indicator_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this.settings.bind(
             'allow-zero-brightness',
             this._allow_zero_brightness_switch,
             'active',
@@ -78,6 +87,14 @@ const PrefsWidget = GObject.registerClass({
         this._decrease_shortcut_button.connect('clicked', widget => {
             this.settings.set_strv('decrease-brightness-shortcut', [this._decrease_shortcut_entry.text]);
         });
+    }
+
+    onButtonLocationChanged() {
+        if (this._button_location_combo_button.active_id == "menu") {
+            this._system_menu_revealer.reveal_child = true;
+        } else {
+            this._system_menu_revealer.reveal_child = false;
+        }
     }
 
 }

--- a/display-brightness-ddcutil@themightydeity.github.com/prefs.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/prefs.js
@@ -15,6 +15,7 @@ const PrefsWidget = GObject.registerClass({
         'button_location_combo_button',
         'system_menu_revealer',
         'hide_system_indicator_switch',
+        'position_system_menu_spin_button',
         'increase_shortcut_entry',
         'decrease_shortcut_entry',
         'increase_shortcut_button',
@@ -63,6 +64,8 @@ const PrefsWidget = GObject.registerClass({
             Gio.SettingsBindFlags.DEFAULT
         );
 
+        this._position_system_menu_spin_button.value = this.settings.get_double('position-system-menu');
+
         this.settings.bind(
             'allow-zero-brightness',
             this._allow_zero_brightness_switch,
@@ -95,6 +98,10 @@ const PrefsWidget = GObject.registerClass({
         } else {
             this._system_menu_revealer.reveal_child = false;
         }
+    }
+
+    onValueChanged() {
+        this.settings.set_double('position-system-menu', this._position_system_menu_spin_button.value);
     }
 
 }

--- a/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
+++ b/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
@@ -17,13 +17,17 @@
       <default>true</default>
       <summary>Show Display Name</summary>
     </key>
-    <key name="button-location" type="s">
+    <key type="s" name="button-location">
       <choices>
         <choice value="panel"/>
         <choice value="menu"/>
       </choices>
       <default>"panel"</default>
       <summary>Brightness Button Location</summary>
+    </key>
+    <key type="b" name="hide-system-indicator">
+      <default>false</default>
+      <summary>Hides System Indicator</summary>
     </key>
     <key type="as" name="increase-brightness-shortcut">
       <default><![CDATA[['<Ctrl><Alt><Shift>h']]]></default>

--- a/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
+++ b/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
@@ -29,6 +29,10 @@
       <default>false</default>
       <summary>Hides System Indicator</summary>
     </key>
+    <key type="d" name="position-system-menu">
+      <default>3</default>
+      <summary>Sets position in system menu</summary>
+    </key>
     <key type="as" name="increase-brightness-shortcut">
       <default><![CDATA[['<Ctrl><Alt><Shift>h']]]></default>
       <summary>Increase Brightness Shortcut</summary>

--- a/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
@@ -171,28 +171,67 @@
                           <object class="GtkRevealer" id="system_menu_revealer">
                             <property name="reveal-child" bind-source="button_location_combo_button" bind-property="active-id" bind-flags="sync-create"/>
                             <child>
-                              <object class="GtkListBoxRow" id="hide_system_indicator_row">
-                                  <child>
-                                    <object class="GtkBox" id="hide_system_indicator_pref_box">
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-top">12</property>
-                                    <property name="margin-bottom">12</property>
-                                    <property name="orientation">vertical</property>
-                                    <child>
-                                      <object class="GtkBox" id="hide_system_indicator_box">
-                                        <property name="spacing">32</property>
+                              <object class="GtkListBox" id="system_menu_listbox">
+                                <property name="selection-mode">none</property>
+                                <child>
+                                  <object class="GtkListBoxRow" id="hide_system_indicator_row">
+                                      <child>
+                                        <object class="GtkBox" id="hide_system_indicator_pref_box">
+                                        <property name="margin-start">12</property>
+                                        <property name="margin-end">12</property>
+                                        <property name="margin-top">12</property>
+                                        <property name="margin-bottom">12</property>
+                                        <property name="orientation">vertical</property>
                                         <child>
-                                          <object class="GtkLabel">
-                                            <property name="valign">center</property>
-                                            <property name="label" translatable="yes">Hide System Indicator</property>
-                                            <property name="xalign">0</property>
-                                            <property name="hexpand">1</property>
+                                          <object class="GtkBox" id="hide_system_indicator_box">
+                                            <property name="spacing">32</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="valign">center</property>
+                                                <property name="label" translatable="yes">Hide System Indicator</property>
+                                                <property name="xalign">0</property>
+                                                <property name="hexpand">1</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="hide_system_indicator_switch">
+                                                <property name="valign">center</property>
+                                              </object>
+                                            </child>
                                           </object>
                                         </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkListBoxRow" id="position_system_menu_row">
+                                      <child>
+                                        <object class="GtkBox" id="position_system_menu_pref_box">
+                                        <property name="margin-start">12</property>
+                                        <property name="margin-end">12</property>
+                                        <property name="margin-top">12</property>
+                                        <property name="margin-bottom">12</property>
+                                        <property name="orientation">vertical</property>
                                         <child>
-                                          <object class="GtkSwitch" id="hide_system_indicator_switch">
-                                            <property name="valign">center</property>
+                                          <object class="GtkBox" id="position_system_menu_box">
+                                            <property name="spacing">32</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="valign">center</property>
+                                                <property name="label" translatable="yes">Position in System Menu</property>
+                                                <property name="xalign">0</property>
+                                                <property name="hexpand">1</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="position_system_menu_spin_button">
+                                                <property name="valign">center</property>
+                                                <property name="numeric">True</property>
+                                                <property name="adjustment">position_system_menu_adjustment</property>
+                                                <signal name="value-changed" handler="onValueChanged" swapped="no"/>
+                                              </object>
+                                            </child>
                                           </object>
                                         </child>
                                       </object>
@@ -392,4 +431,9 @@
       </object>
     </child>
   </template>
+  <object class="GtkAdjustment" id="position_system_menu_adjustment">
+    <property name="lower">0</property>
+    <property name="upper">13</property>
+    <property name="step-increment">1</property>
+  </object>
 </interface>

--- a/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
@@ -154,10 +154,47 @@
                                     <child>
                                       <object class="GtkComboBoxText" id="button_location_combo_button">
                                         <property name="active-id">panel</property>
+                                        <signal name="notify::active" handler="onButtonLocationChanged" swapped="no"/>
                                         <items>
                                           <item id="panel" translatable="yes">Top Bar</item>
                                           <item id="menu" translatable="yes">System Menu</item>
                                         </items>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkRevealer" id="system_menu_revealer">
+                            <property name="reveal-child" bind-source="button_location_combo_button" bind-property="active-id" bind-flags="sync-create"/>
+                            <child>
+                              <object class="GtkListBoxRow" id="hide_system_indicator_row">
+                                  <child>
+                                    <object class="GtkBox" id="hide_system_indicator_pref_box">
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-top">12</property>
+                                    <property name="margin-bottom">12</property>
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <object class="GtkBox" id="hide_system_indicator_box">
+                                        <property name="spacing">32</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="valign">center</property>
+                                            <property name="label" translatable="yes">Hide System Indicator</property>
+                                            <property name="xalign">0</property>
+                                            <property name="hexpand">1</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSwitch" id="hide_system_indicator_switch">
+                                            <property name="valign">center</property>
+                                          </object>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>


### PR DESCRIPTION
These configs work properly with the solution proposed in https://github.com/daitj/gnome-display-brightness-ddcutil/issues/41 but I did not apply it here because it seems like a workaround.

853e3b6f0ce37a473bf55ff8d245e784f0217535:

![imagen](https://user-images.githubusercontent.com/42654671/148310951-97187dc7-5d76-4e75-980b-1f8a286475e6.png)

![imagen](https://user-images.githubusercontent.com/42654671/148310997-2d2690e1-4047-46b0-936d-87688b5ff021.png)

06c683bdd31d088ad5b470bcf848d7cb2f353c47:

I could only get the system menu layout to update by logging out.

Current behavior for me:
![imagen](https://user-images.githubusercontent.com/42654671/148311229-fdbbdf0f-999b-4bb4-bb20-3c1af1ef108b.png)

![imagen](https://user-images.githubusercontent.com/42654671/148311099-540e1559-7d6f-479f-b5b4-fca6fe59e2e3.png)

The first brightness slider is from the integrated display.