### PR TITLE
Fix a check for presence of a string

### DIFF
--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -311,7 +311,7 @@ function parseDisplaysInfoAndAddToPanel(settings, ddcutil_brief_info) {
                 });
 
             }
-            if (ddc_line.indexOf("Monitor:") !== -1) {
+            if (ddc_line.indexOf(_("Monitor:")) !== -1) {
                 /* Monitor name comes second in the output,
                  so when that is detected fill the object and push it to list */
                 display_names[diplay_loop_id] = ddc_line.split(_("Monitor:"))[1].trim().split(":")[1].trim()


### PR DESCRIPTION
My system uses German language and after the recent update I am getting the following error message in the log:

```
display-brightness-ddcutil extension:
TypeError: ddc_line.split(...)[1] is undefined
```

My take is that the current `ddc_line.indexOf("Monitor:")` checks for the presence of untranslated string, while the following call for `ddc_line.split(_("Monitor:"))` uses the translated string. I also assume that the translated string is used here intentionally, so I updated the check accordingly.

I must note, however, that on my system the output of `ddcutil detect --brief` is not translated into English:

```
Invalid display
   I2C bus:             /dev/i2c-12
   Monitor:             SHP::

Display 1
   I2C bus:             /dev/i2c-15
   Monitor:             GSM:LG HDR 4K:
```

So in my case the solution I propose results in the undefined name of the monitor. I think you have a stronger opinion on how to address that.

