### PR TITLE
Improve keyboard shortcut editor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ build: schemas
 		--extra-source=ui \
 		--extra-source=convenience.js \
 		--extra-source=indicator.js \
+		--extra-source=shortcut.js \
 		./display-brightness-ddcutil@themightydeity.github.com/ \
 		--out-dir=./dist
 

--- a/README.md
+++ b/README.md
@@ -106,3 +106,6 @@ This extension is developed and maintained by [@daitj](https://github.com/daitj)
 
 #### Thanks to the following people for contributing via pull requests:
 - @oscfdezdz for adding new settings ui, keyboard shortcuts and ability to set icon location
+
+#### Thanks to the following extensions for the inspiration:
+- [Night Theme Switcher](https://extensions.gnome.org/extension/2236/night-theme-switcher/)

--- a/display-brightness-ddcutil@themightydeity.github.com/convenience.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/convenience.js
@@ -26,7 +26,7 @@
 */
 
 const Gettext = imports.gettext;
-const { GLib, Gio } = imports.gi;
+const { Gdk, Gio, GLib, Gtk } = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 
@@ -80,4 +80,67 @@ function spawnWithCallback(argv, callback) {
       brightnessLog(e.message);
     }
   });
+}
+
+/**
+ * Check if the given keyval is forbidden.
+ *
+ * @param {number} keyval The keyval number.
+ * @returns {boolean} `true` if the keyval is forbidden.
+ */
+ function isKeyvalForbidden(keyval) {
+  const forbiddenKeyvals = [
+      Gdk.KEY_Home,
+      Gdk.KEY_Left,
+      Gdk.KEY_Up,
+      Gdk.KEY_Right,
+      Gdk.KEY_Down,
+      Gdk.KEY_Page_Up,
+      Gdk.KEY_Page_Down,
+      Gdk.KEY_End,
+      Gdk.KEY_Tab,
+      Gdk.KEY_KP_Enter,
+      Gdk.KEY_Return,
+      Gdk.KEY_Mode_switch,
+  ];
+  return forbiddenKeyvals.includes(keyval);
+}
+
+/**
+ * Check if the given key combo is a valid binding
+ *
+ * @param {{mask: number, keycode: number, keyval:number}} combo An object
+ * representing the key combo.
+ * @returns {boolean} `true` if the key combo is a valid binding.
+ */
+ function isBindingValid({ mask, keycode, keyval }) {
+  if ((mask === 0 || mask === Gdk.SHIFT_MASK) && keycode !== 0) {
+      if (
+          (keyval >= Gdk.KEY_a && keyval <= Gdk.KEY_z) ||
+          (keyval >= Gdk.KEY_A && keyval <= Gdk.KEY_Z) ||
+          (keyval >= Gdk.KEY_0 && keyval <= Gdk.KEY_9) ||
+          (keyval >= Gdk.KEY_kana_fullstop && keyval <= Gdk.KEY_semivoicedsound) ||
+          (keyval >= Gdk.KEY_Arabic_comma && keyval <= Gdk.KEY_Arabic_sukun) ||
+          (keyval >= Gdk.KEY_Serbian_dje && keyval <= Gdk.KEY_Cyrillic_HARDSIGN) ||
+          (keyval >= Gdk.KEY_Greek_ALPHAaccent && keyval <= Gdk.KEY_Greek_omega) ||
+          (keyval >= Gdk.KEY_hebrew_doublelowline && keyval <= Gdk.KEY_hebrew_taf) ||
+          (keyval >= Gdk.KEY_Thai_kokai && keyval <= Gdk.KEY_Thai_lekkao) ||
+          (keyval >= Gdk.KEY_Hangul_Kiyeog && keyval <= Gdk.KEY_Hangul_J_YeorinHieuh) ||
+          (keyval === Gdk.KEY_space && mask === 0) ||
+          isKeyvalForbidden(keyval)
+      )
+          return false;
+  }
+  return true;
+}
+
+/**
+* Check if the given key combo is a valid accelerator.
+*
+* @param {{mask: number, keyval:number}} combo An object representing the key
+* combo.
+* @returns {boolean} `true` if the key combo is a valid accelerator.
+*/
+function isAccelValid({ mask, keyval }) {
+  return Gtk.accelerator_valid(keyval, mask) || (keyval === Gdk.KEY_Tab && mask !== 0);
 }

--- a/display-brightness-ddcutil@themightydeity.github.com/prefs.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/prefs.js
@@ -1,7 +1,9 @@
 const { Adw, Gio, GObject } = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+
 const Convenience = Me.imports.convenience;
+const ShortcutWidget = Me.imports.shortcut;
 
 const PrefsWidget = GObject.registerClass({
     GTypeName: 'PrefsWidget',
@@ -17,8 +19,6 @@ const PrefsWidget = GObject.registerClass({
         'position_system_menu_row',
         'hide_system_indicator_switch',
         'position_system_menu_spin_button',
-        'increase_shortcut_entry',
-        'decrease_shortcut_entry',
         'increase_shortcut_button',
         'decrease_shortcut_button',
         'step_keyboard_spin_button',
@@ -97,16 +97,21 @@ const PrefsWidget = GObject.registerClass({
             Gio.SettingsBindFlags.DEFAULT
         );
 
-        this._increase_shortcut_entry.text = this.settings.get_strv('increase-brightness-shortcut')[0];
-        this._decrease_shortcut_entry.text = this.settings.get_strv('decrease-brightness-shortcut')[0];
-
-        this._increase_shortcut_button.connect('clicked', widget => {
-            this.settings.set_strv('increase-brightness-shortcut', [this._increase_shortcut_entry.text]);
+        this.settings.connect('changed::increase-brightness-shortcut', () => {
+            this._increase_shortcut_button.keybinding = this.settings.get_strv('increase-brightness-shortcut')[0];
         });
-
-        this._decrease_shortcut_button.connect('clicked', widget => {
-            this.settings.set_strv('decrease-brightness-shortcut', [this._decrease_shortcut_entry.text]);
+        this._increase_shortcut_button.connect('notify::keybinding', () => {
+            this.settings.set_strv('increase-brightness-shortcut', [this._increase_shortcut_button.keybinding]);
         });
+        this._increase_shortcut_button.keybinding = this.settings.get_strv('increase-brightness-shortcut')[0];
+
+        this.settings.connect('changed::decrease-brightness-shortcut', () => {
+            this._decrease_shortcut_button.keybinding = this.settings.get_strv('decrease-brightness-shortcut')[0];
+        });
+        this._decrease_shortcut_button.connect('notify::keybinding', () => {
+            this.settings.set_strv('decrease-brightness-shortcut', [this._decrease_shortcut_button.keybinding]);
+        });
+        this._decrease_shortcut_button.keybinding = this.settings.get_strv('decrease-brightness-shortcut')[0];
     }
 
     onButtonLocationChanged() {

--- a/display-brightness-ddcutil@themightydeity.github.com/shortcut.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/shortcut.js
@@ -1,0 +1,66 @@
+const { Gdk, GLib, GObject, Gtk } = imports.gi;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+
+const Convenience = Me.imports.convenience;
+
+const ShortcutWidget = GObject.registerClass({
+    GTypeName: 'ShortcutWidget',
+    Template: Me.dir.get_child('./ui/shortcut.ui').get_uri(),
+    InternalChildren: [
+        'set_button',
+        'clear_button',
+        'dialog'
+    ],
+    Properties: {
+        keybinding: GObject.ParamSpec.string(
+            'keybinding',
+            'Keybinding',
+            'Key sequence',
+            GObject.ParamFlags.READWRITE,
+            null
+        ),
+    },
+}, class ShortcutWidget extends Gtk.Stack {
+
+    onKeybindingChanged(button) {
+        button.visible_child_name = button.keybinding ? 'edit' : 'set';
+    }
+
+    onSetButtonClicked(_button) {
+        this._dialog.transient_for = this.get_root();
+        this._dialog.present();
+    }
+
+    onClearButtonClicked(_button) {
+        this.keybinding = '';
+    }
+
+    onKeyPressed(_widget, keyval, keycode, state) {
+        let mask = state & Gtk.accelerator_get_default_mod_mask();
+        mask &= ~Gdk.ModifierType.LOCK_MASK;
+
+        if (mask === 0 && keyval === Gdk.KEY_Escape) {
+            this._dialog.close();
+            return Gdk.EVENT_STOP;
+        }
+
+        if (
+            !Convenience.isBindingValid({ mask, keycode, keyval }) ||
+            !Convenience.isAccelValid({ mask, keyval })
+        )
+            return Gdk.EVENT_STOP;
+
+        this.keybinding = Gtk.accelerator_name_with_keycode(
+            null,
+            keyval,
+            keycode,
+            mask
+        );
+
+        this._dialog.close();
+
+        return Gdk.EVENT_STOP;
+    }
+
+});

--- a/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
@@ -95,7 +95,6 @@
             <property name="title" translatable="yes">Position in System Menu</property>
             <property name="selectable">False</property>
             <property name="focusable">False</property>
-            <property name="activatable-widget">position_system_menu_spin_button</property>
             <child>
               <object class="GtkSpinButton" id="position_system_menu_spin_button">
                 <property name="valign">center</property>
@@ -117,13 +116,7 @@
             <property name="selectable">False</property>
             <property name="focusable">False</property>
             <child>
-              <object class="GtkEntry" id="increase_shortcut_entry">
-                <property name="valign">center</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkButton" id="increase_shortcut_button">
-                <property name="label" translatable="yes">Apply</property>
+              <object class="ShortcutWidget" id="increase_shortcut_button">
                 <property name="valign">center</property>
               </object>
             </child>
@@ -135,13 +128,7 @@
             <property name="selectable">False</property>
             <property name="focusable">False</property>
             <child>
-              <object class="GtkEntry" id="decrease_shortcut_entry">
-                <property name="valign">center</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkButton" id="decrease_shortcut_button">
-                <property name="label" translatable="yes">Apply</property>
+              <object class="ShortcutWidget" id="decrease_shortcut_button">
                 <property name="valign">center</property>
               </object>
             </child>

--- a/display-brightness-ddcutil@themightydeity.github.com/ui/shortcut.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/shortcut.ui
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface domain="display-brightness-ddcutil">
+  <template class="ShortcutWidget" parent="GtkStack">
+    <property name="hhomogeneous">False</property>
+    <signal name="notify::keybinding" handler="onKeybindingChanged" swapped="no"/>
+    <child>
+      <object class="GtkStackPage">
+        <property name="name">set</property>
+        <property name="child">
+          <object class="GtkButton" id="set_button">
+            <property name="label" translatable="yes">Set Shortcut…</property>
+            <signal name="clicked" handler="onSetButtonClicked" swapped="no"/>
+          </object>
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkStackPage">
+        <property name="name">edit</property>
+        <property name="child">
+          <object class="GtkBox">
+            <property name="orientation">horizontal</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkShortcutLabel">
+                <property name="accelerator" bind-source="ShortcutWidget" bind-property="keybinding"/>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="clear_button">
+                <property name="icon-name">edit-clear-symbolic</property>
+                <signal name="clicked" handler="onClearButtonClicked" swapped="no"/>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </property>
+      </object>
+    </child>
+  </template>
+  <object class="AdwWindow" id="dialog">
+    <property name="modal">True</property>
+    <property name="hide-on-close">True</property>
+    <property name="default-width">400</property>
+    <property name="content">
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="AdwHeaderBar">
+            <property name="show-start-title-buttons">False</property>
+            <property name="show-end-title-buttons">False</property>
+            <child type="title">
+              <object class="AdwWindowTitle">
+                <property name="title" translatable="yes">Add Custom Shortcut</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="orientation">vertical</property>
+            <property name="margin-top">12</property>
+            <property name="margin-bottom">12</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Enter the new shortcut</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">input-keyboard-symbolic</property>
+                <property name="pixel-size">128</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Press Esc to cancel the keyboard shortcut.</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </property>
+    <child>
+      <object class="GtkEventControllerKey">
+        <signal name="key-pressed" handler="onKeyPressed" swapped="no"/>
+      </object>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
Most of the code in this PR is from [Night Theme Switcher GNOME Shell extension](https://gitlab.com/rmnvgr/nightthemeswitcher-gnome-shell-extension). I'm still checking the [LICENSE](https://gitlab.com/rmnvgr/nightthemeswitcher-gnome-shell-extension/-/blob/main/LICENSE.md) as I'm not sure how these things have to be done.

Close https://github.com/daitj/gnome-display-brightness-ddcutil/issues/69