### PR TITLE
Add setting for ddcutil binary path

### DIFF
--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -62,8 +62,6 @@ let mainMenuButton = null;
 const cache_dir = GLib.get_user_cache_dir()
 const ddcutil_detect_cache_file = `${cache_dir}/ddcutil_detect`;
 
-const ddcutil_path = "/usr/bin/ddcutil";
-
 class DDCUtilBrightnessControlExtension {
     constructor() { }
     enable() {
@@ -146,6 +144,7 @@ function setBrightness(settings, display, newValue) {
             newBrightness = minBrightness;
         }
     }
+    const ddcutil_path = settings.get_string('ddcutil-binary-path')
     const sleepMultiplier = (settings.get_double('ddcutil-sleep-multiplier'))/40;
     //brightnessLog(`${ddcutil_path} setvcp 10 ${newBrightness} --bus ${display.bus}`)
     GLib.spawn_command_line_async(`${ddcutil_path} setvcp 10 ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier}`)
@@ -293,6 +292,7 @@ function addTextItemToPanel(text) {
 
 function parseDisplaysInfoAndAddToPanel(settings, ddcutil_brief_info) {
     try {
+        const ddcutil_path = settings.get_string('ddcutil-binary-path')
         let display_names = [];
         /*
         due to spawnWithCallback fetching faster information for second display in list before first one
@@ -365,6 +365,7 @@ function parseDisplaysInfoAndAddToPanel(settings, ddcutil_brief_info) {
 }
 
 function getDisplaysInfoAsync(settings) {
+    const ddcutil_path = settings.get_string('ddcutil-binary-path')
     Convenience.spawnWithCallback([ddcutil_path, "detect", "--brief"], function (stdout) {
         parseDisplaysInfoAndAddToPanel(settings, stdout);
     });

--- a/display-brightness-ddcutil@themightydeity.github.com/po/de.po
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-13 11:24+0200\n"
+"POT-Creation-Date: 2022-12-30 00:29+1000\n"
 "PO-Revision-Date: 2022-02-13 09:53+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -81,24 +81,28 @@ msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:174
+msgid "`ddcutil` Binary Path"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:187
 msgid "`ddcutil` Sleep Multiplier ms"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:189
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:202
 #, fuzzy
 msgid "Allow Zero Brightness"
 msgstr "Vollständige Abdunkelung erlauben"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:202
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:215
 #, fuzzy
 msgid "Disable Display State Check"
 msgstr "Status-Überprüfung deaktivieren"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:218
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:231
 msgid "Top Bar"
 msgstr "Obere Leiste"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:219
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:232
 msgid "System Menu"
 msgstr "System-Menü"
 
@@ -119,19 +123,19 @@ msgstr ""
 msgid "Press Esc to cancel the keyboard shortcut."
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:106
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:104
 msgid "Initializing"
 msgstr "Initialisiere"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:163
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:162
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:169
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:168
 msgid "Reload"
 msgstr "Neu laden"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:180
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:179
 msgid "All"
 msgstr "Alle"
 

--- a/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-13 11:31+0200\n"
+"POT-Creation-Date: 2022-12-30 00:29+1000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -78,22 +78,26 @@ msgid "Advanced Settings"
 msgstr ""
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:174
+msgid "`ddcutil` Binary Path"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:187
 msgid "`ddcutil` Sleep Multiplier ms"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:189
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:202
 msgid "Allow Zero Brightness"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:202
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:215
 msgid "Disable Display State Check"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:218
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:231
 msgid "Top Bar"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:219
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:232
 msgid "System Menu"
 msgstr ""
 
@@ -113,18 +117,18 @@ msgstr ""
 msgid "Press Esc to cancel the keyboard shortcut."
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:106
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:104
 msgid "Initializing"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:163
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:162
 msgid "Settings"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:169
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:168
 msgid "Reload"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:180
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:179
 msgid "All"
 msgstr ""

--- a/display-brightness-ddcutil@themightydeity.github.com/po/es.po
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-display-brightness-ddcutil\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-13 11:24+0200\n"
+"POT-Creation-Date: 2022-12-30 00:29+1000\n"
 "PO-Revision-Date: 2022-08-24 12:05+0200\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@tuta.io>\n"
 "Language-Team: \n"
@@ -80,22 +80,26 @@ msgid "Advanced Settings"
 msgstr "Configuración avanzada"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:174
+msgid "`ddcutil` Binary Path"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:187
 msgid "`ddcutil` Sleep Multiplier ms"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:189
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:202
 msgid "Allow Zero Brightness"
 msgstr "Permitir brillo cero"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:202
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:215
 msgid "Disable Display State Check"
 msgstr "Desactivar la comprobación del estado de la pantalla"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:218
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:231
 msgid "Top Bar"
 msgstr "Barra superior"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:219
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:232
 msgid "System Menu"
 msgstr "Menú del sistema"
 
@@ -115,18 +119,18 @@ msgstr "Introduzca el atajo nuevo"
 msgid "Press Esc to cancel the keyboard shortcut."
 msgstr "Pulse Esc para cancelar el atajo del teclado."
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:106
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:104
 msgid "Initializing"
 msgstr "Inicializando"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:163
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:162
 msgid "Settings"
 msgstr "Configuración"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:169
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:168
 msgid "Reload"
 msgstr "Recargar"
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:180
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:179
 msgid "All"
 msgstr "Todos"

--- a/display-brightness-ddcutil@themightydeity.github.com/prefs.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/prefs.js
@@ -24,6 +24,7 @@ const PrefsWidget = GObject.registerClass({
         'increase_shortcut_button',
         'decrease_shortcut_button',
         'step_keyboard_spin_button',
+        'ddcutil_binary_path_entry',
         'sleep_multiplier_spin_button',
         'allow_zero_brightness_switch',
         'disable_display_state_check_switch'
@@ -85,6 +86,7 @@ const PrefsWidget = GObject.registerClass({
         this._position_system_indicator_spin_button.value = this.settings.get_double('position-system-indicator');
         this._position_system_menu_spin_button.value = this.settings.get_double('position-system-menu');
         this._step_keyboard_spin_button.value = this.settings.get_double('step-change-keyboard');
+        this._ddcutil_binary_path_entry.set_text(this.settings.get_string('ddcutil-binary-path'))
         this._sleep_multiplier_spin_button.value = this.settings.get_double('ddcutil-sleep-multiplier');
         
         this.settings.bind(
@@ -144,6 +146,9 @@ const PrefsWidget = GObject.registerClass({
     }
     onStepKeyboardValueChanged() {
         this.settings.set_double('step-change-keyboard', this._step_keyboard_spin_button.value);
+    }
+    onDdcutilBinaryPathChanged() {
+        this.settings.set_string('ddcutil-binary-path', this._ddcutil_binary_path_entry.get_text());
     }
     onSleepMultiplierValueChanged() {
         this.settings.set_double('ddcutil-sleep-multiplier', this._sleep_multiplier_spin_button.value);

--- a/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
+++ b/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
@@ -53,6 +53,10 @@
       <default>2</default>
       <summary>Step change % when using keyboard shortcut</summary>
     </key>
+    <key type="s" name="ddcutil-binary-path">
+      <default><![CDATA['/usr/bin/ddcutil']]></default>
+      <summary>Location of the ddcutil binary to use</summary>
+    </key>
     <key type="d" name="ddcutil-sleep-multiplier">
       <range min="4" max="200" />
       <default>40</default>

--- a/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
@@ -170,6 +170,19 @@
       <object class="AdwPreferencesGroup">
         <property name="title" translatable="yes">Advanced Settings</property>
         <child>
+          <object class="AdwActionRow" id="ddcutil_binary_path_row">
+            <property name="title" translatable="yes">`ddcutil` Binary Path</property>
+            <property name="selectable">False</property>
+            <property name="focusable">False</property>
+            <child>
+              <object class="GtkEntry" id="ddcutil_binary_path_entry">
+                <property name="valign">center</property>
+                <signal name="changed" handler="onDdcutilBinaryPathChanged" swapped="no" />
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
           <object class="AdwActionRow" id="sleep_multiplier_row">
             <property name="title" translatable="yes">`ddcutil` Sleep Multiplier ms</property>
             <property name="selectable">False</property>


### PR DESCRIPTION
This allows the extension to work on systems with ddcutil installed in locations other than /usr/bin/ddcutil.