### PR TITLE
allow to specify additional ddcutil args

### DIFF
--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -199,11 +199,12 @@ function setBrightness(settings, display, newValue) {
             newBrightness = minBrightness;
         }
     }
-    const ddcutil_path = settings.get_string('ddcutil-binary-path')
+    const ddcutilPath = settings.get_string('ddcutil-binary-path');
+    const ddcutilAdditionalArgs = settings.get_string('ddcutil-additional-args');
     const sleepMultiplier = (settings.get_double('ddcutil-sleep-multiplier'))/40;
     const writer = ()=>{
-        brightnessLog(`async ${ddcutil_path} setvcp 10 ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier}`);
-        GLib.spawn_command_line_async(`${ddcutil_path} setvcp 10 ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier}`)
+        brightnessLog(`async ${ddcutilPath} setvcp 10 ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
+        GLib.spawn_command_line_async(`${ddcutilPath} setvcp 10 ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`)
     }
     brightnessLog(`display ${display.name}, current: ${display.current} => ${newValue/100}, new brightness: ${newBrightness}, new value: ${newValue}`);
     display.current = newValue/100

--- a/display-brightness-ddcutil@themightydeity.github.com/prefs.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/prefs.js
@@ -27,6 +27,7 @@ const PrefsWidget = GObject.registerClass({
         'ddcutil_binary_path_entry',
         'sleep_multiplier_spin_button',
         'queue_ms_spin_button',
+        'ddcutil_additional_args_entry',
         'allow_zero_brightness_switch',
         'disable_display_state_check_switch',
         'verbose_debugging_switch'
@@ -89,6 +90,7 @@ const PrefsWidget = GObject.registerClass({
         this._position_system_menu_spin_button.value = this.settings.get_double('position-system-menu');
         this._step_keyboard_spin_button.value = this.settings.get_double('step-change-keyboard');
         this._ddcutil_binary_path_entry.set_text(this.settings.get_string('ddcutil-binary-path'))
+        this._ddcutil_additional_args_entry.set_text(this.settings.get_string('ddcutil-additional-args'));
         this._sleep_multiplier_spin_button.value = this.settings.get_double('ddcutil-sleep-multiplier');
         this._queue_ms_spin_button.value = this.settings.get_double('ddcutil-queue-ms');
         
@@ -160,6 +162,9 @@ const PrefsWidget = GObject.registerClass({
     }
     onDdcutilBinaryPathChanged() {
         this.settings.set_string('ddcutil-binary-path', this._ddcutil_binary_path_entry.get_text());
+    }
+    onDdcutilAdditionalArgsChanged() {
+        this.settings.set_string('ddcutil-additional-args', this._ddcutil_additional_args_entry.get_text());
     }
     onSleepMultiplierValueChanged() {
         this.settings.set_double('ddcutil-sleep-multiplier', this._sleep_multiplier_spin_button.value);

--- a/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
+++ b/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
@@ -58,6 +58,10 @@
       <default><![CDATA['/usr/bin/ddcutil']]></default>
       <summary>Location of the ddcutil binary to use</summary>
     </key>
+    <key type="s" name="ddcutil-additional-args">
+      <default><![CDATA['']]></default>
+      <summary>Additional arguments for ddcutil when setting brightness</summary>
+    </key>
     <key type="d" name="ddcutil-sleep-multiplier">
       <range min="4" max="200" />
       <default>40</default>

--- a/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
@@ -183,6 +183,19 @@
           </object>
         </child>
         <child>
+          <object class="AdwActionRow" id="ddcutil_addional_args_row">
+            <property name="title" translatable="yes">`ddcutil` Additional Arguments</property>
+            <property name="selectable">False</property>
+            <property name="focusable">False</property>
+            <child>
+              <object class="GtkEntry" id="ddcutil_additional_args_entry">
+                <property name="valign">center</property>
+                <signal name="changed" handler="onDdcutilAdditionalArgsChanged" swapped="no" />
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
           <object class="AdwActionRow" id="sleep_multiplier_row">
             <property name="title" translatable="yes">`ddcutil` Sleep Multiplier ms</property>
             <property name="selectable">False</property>


### PR DESCRIPTION
This change adds the ability to specify additional arguments to ddcutil.
It was necessary for me as I have one display which requires `--noverify` to accept the brightness value. 