### PR TITLE
Fix for ddcutil v2.0.0 support

### DIFF
--- a/display-brightness-ddcutil@themightydeity.github.com/convenienceExt.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/convenienceExt.js
@@ -34,3 +34,13 @@ export function spawnWithCallback(settings, argv, callback) {
     });
 }
 
+
+/**
+ * Filters a VCP Feature Codes output to make sure only valid lines are returned.
+ *
+ * @param {string} val The `getvcp` feature code output
+ * @returns {string} An array containing valid VPC lines, e.g. 'VPC D6 SNC 0x1'
+ */
+export function filterVCPInfoSpecification(val) {
+    return val.trim().match(/^VCP.*$/gm).join('\n')
+}

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -41,6 +41,7 @@ const {
 const {
     brightnessLog,
     spawnWithCallback,
+    filterVCPInfoSpecification
 } = Convenience;
 
 /*
@@ -416,7 +417,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                         brightnessLog(this.settings, `ddcutil reading display status for bus: ${displayBus} is: ${vcpPowerInfos}`);
                         /* only add display to list if ddc communication is supported with the bus*/
                         if (vcpPowerInfos.indexOf('DDC communication failed') === -1 && vcpPowerInfos.indexOf('No monitor detected') === -1) {
-                            const vcpPowerInfosArray = vcpPowerInfos.trim().split(' ');
+                            const vcpPowerInfosArray = filterVCPInfoSpecification(vcpPowerInfos).split(' ')
 
                             let displayInGoodState = true;
                             if (!this.settings.get_boolean('disable-display-state-check')) {
@@ -430,7 +431,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                 /* read the current and max brightness using getvcp 10 */
                                 spawnWithCallback(this.settings, [ddcutilPath, 'getvcp', '--brief', '10', '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()], vcpInfos  => {
                                     if (vcpInfos.indexOf('DDC communication failed') === -1 && vcpInfos.indexOf('No monitor detected') === -1) {
-                                        const vcpInfosArray = vcpInfos.trim().split(' ');
+                                        const vcpInfosArray = filterVCPInfoSpecification(vcpInfos).split(' ');
                                         if (vcpInfosArray[2] !== 'ERR' && vcpInfosArray.length >= 5) {
                                             let display = {};
 


### PR DESCRIPTION
This change fixes an issue with `ddcutil` version 2.0.0, where `getvcp` would prints warnings, even if `--verbose` is not passed.

Check out this bug report on the `ddcutil` repository:
https://github.com/rockowitz/ddcutil/issues/348

Even with the fix already available on version 2.0.2-dev, I believe it is still small change is still worth while to ensure backward compatibility. Furthermore it is extra insurance for issues that could arise in the future.

This fixes issue:
https://github.com/daitj/gnome-display-brightness-ddcutil/issues/115

Tested on Alienware AW3423DWF