### PR TITLE
GNOME 46 support

### DIFF
--- a/display-brightness-ddcutil@themightydeity.github.com/metadata.json
+++ b/display-brightness-ddcutil@themightydeity.github.com/metadata.json
@@ -5,8 +5,8 @@
     "url": "https://github.com/daitj/gnome-display-brightness-ddcutil",
     "settings-schema": "org.gnome.shell.extensions.display-brightness-ddcutil",
     "gettext-domain": "display-brightness-ddcutil",
-    "version": 48,
+    "version": 49,
     "shell-version": [
-        "45"
+        "45", "46"
     ]
 }


### PR DESCRIPTION
As said in https://github.com/daitj/gnome-display-brightness-ddcutil/issues/131, extension just works with GNOME 46 after version bump.