### PR TITLE
fix #129: bind class method

### DIFF
--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -577,7 +577,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
 
     connectMonitorChangeSignals() {
         monitorSignals = {
-            change: Main.layoutManager.connect('monitors-changed', this.onMonitorChange),
+            change: Main.layoutManager.connect('monitors-changed', this.onMonitorChange.bind(this)),
         };
     }
 


### PR DESCRIPTION
I have also noticed the error reported in #129 and figured out that the class method passed as a callback loses `this` reference, so it has to be bound