### PR TITLE
Enhance README: Shields to capture the attention of potential contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ As a workaround I changed this extension to read cached info from a file, when i
 ```sh
 ddcutil --brief detect > $XDG_CACHE_HOME/ddcutil_detect
 ```
+## Contributing
+
+[![GitHub repo Good Issues for newbies](https://img.shields.io/github/issues/daitj/gnome-display-brightness-ddcutil/good%20first%20issue?style=flat&logo=github&logoColor=green&label=Good%20First%20issues)](https://github.com/daitj/gnome-display-brightness-ddcutil/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) [![GitHub Help Wanted issues](https://img.shields.io/github/issues/daitj/gnome-display-brightness-ddcutil/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20issues)](https://github.com/daitj/gnome-display-brightness-ddcutil/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub Help Wanted PRs](https://img.shields.io/github/issues-pr/daitj/gnome-display-brightness-ddcutil/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20PRs)](https://github.com/daitj/gnome-display-brightness-ddcutil/pulls?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub repo Issues](https://img.shields.io/github/issues/daitj/gnome-display-brightness-ddcutil?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/daitj/gnome-display-brightness-ddcutil/issues?q=is%3Aopen)
+
+👋 **Welcome, new contributors!**
+
+Whether you're a seasoned developer or just getting started, your contributions are valuable to us. Don't hesitate to jump in, explore the project, and make an impact. To start contributing, please check out our [Contribution Guidelines](CONTRIBUTING.md). 
 
 ## Credits
 


### PR DESCRIPTION
I noticed you have opened issues labeled `help wanted`. I recommend enhancing the README to make the call for new contributors more prominent.

### Changes Made:

1. **Shields:** Added Shields.io badges at the top of the README

[![GitHub repo Good Issues for newbies](https://img.shields.io/github/issues/daitj/gnome-display-brightness-ddcutil/good%20first%20issue?style=flat&logo=github&logoColor=green&label=Good%20First%20issues)](https://github.com/daitj/gnome-display-brightness-ddcutil/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) [![GitHub Help Wanted issues](https://img.shields.io/github/issues/daitj/gnome-display-brightness-ddcutil/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20issues)](https://github.com/daitj/gnome-display-brightness-ddcutil/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub Help Wanted PRs](https://img.shields.io/github/issues-pr/daitj/gnome-display-brightness-ddcutil/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20PRs)](https://github.com/daitj/gnome-display-brightness-ddcutil/pulls?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub repo Issues](https://img.shields.io/github/issues/daitj/gnome-display-brightness-ddcutil?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/daitj/gnome-display-brightness-ddcutil/issues?q=is%3Aopen)

```markdown
[![GitHub repo Good Issues for newbies](https://img.shields.io/github/issues/daitj/gnome-display-brightness-ddcutil/good%20first%20issue?style=flat&logo=github&logoColor=green&label=Good%20First%20issues)](https://github.com/daitj/gnome-display-brightness-ddcutil/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) [![GitHub Help Wanted issues](https://img.shields.io/github/issues/daitj/gnome-display-brightness-ddcutil/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20issues)](https://github.com/daitj/gnome-display-brightness-ddcutil/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub Help Wanted PRs](https://img.shields.io/github/issues-pr/daitj/gnome-display-brightness-ddcutil/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20PRs)](https://github.com/daitj/gnome-display-brightness-ddcutil/pulls?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub repo Issues](https://img.shields.io/github/issues/daitj/gnome-display-brightness-ddcutil?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/daitj/gnome-display-brightness-ddcutil/issues?q=is%3Aopen)
```

2. **Welcoming Message:** Enhanced the README with a more prominent and inviting message to welcome new contributors.

### Why This Matters:

- **Attract New Contributors:** Considering there is a number of opened issues labeled 'Help Wanted' - a welcoming and appealing README is one of the most efficient ways to attract new contributors

### Additional Resources:

For more insights into building a strong open-source community, check out the [Building Community guide](https://opensource.guide/building-community/). 

🚀 **Thank you for considering this pull request!** 🚀