### PR TITLE
clarified disable state check by adding a subtitle

### DIFF
--- a/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
@@ -132,6 +132,7 @@
         <child>
           <object class="AdwSwitchRow" id="disable_display_state_check_row">
             <property name="title" translatable="yes">Disable Display State Check</property>
+            <property name="subtitle" translatable="yes">Disables the check for the display power state before changing brightness, might help in detecting more displays</property>
           </object>
         </child>
         <child>


### PR DESCRIPTION
I have been using `ddcutil` cli to adjust brightness and I've never used this extension before. I was having a problem getting this extension to detect my display. 
So I looked through the code only to realize the option `Disable Display State Check` would fix my issue. However the name is confusing as to what exactly is it doing. 