### PR TITLE
Feature: DDC VCP 6B

### DIFF
--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -68,9 +68,9 @@ let pause_sync = false
 let internal_control = true
 
 const ddcVcpBrightnessIds = [
-    //'fa',    // Non-existant; used to test fallback works
-    '6B',      // Backlight Level: White
-    '10',      // Brightness
+    // 'fa',    // Non-existant; used to test fallback works
+    '6B',       // Backlight Level: White
+    '10',       // Brightness
 ];
 
 /*
@@ -565,16 +565,13 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                 /* read the current and max brightness using getvcp */
                                 let ddcutilCall = brightnessIdsIndex =>  [ddcutilPath, 'getvcp', '--brief', ddcVcpBrightnessIds[brightnessIdsIndex], '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()];
                                 let ddutilCallback = (brightnessIdsIndex, vcpInfos) => {
-                                    if (vcpInfos.indexOf('Unsupported feature code') !== -1) {
-                                        brightnessIdsIndex++;
-                                        if (brightnessIdsIndex < ddcVcpBrightnessIds.length) {
-                                            spawnWithCallback(this.settings, ddcutilCall(brightnessIdsIndex), vcpInfos => ddutilCallback(brightnessIdsIndex, vcpInfos));
-                                        };
-                                        return;
-                                    }
                                     if (vcpInfos.indexOf('DDC communication failed') === -1 && vcpInfos.indexOf('No monitor detected') === -1) {
                                         const vcpInfosArray = filterVCPInfoSpecification(vcpInfos).split(' ');
-                                        if (vcpInfosArray[2] !== 'ERR' && vcpInfosArray.length >= 5) {
+                                        if (vcpInfosArray[2] === 'ERR') {
+                                            if (brightnessIdsIndex+1 < ddcVcpBrightnessIds.length) {
+                                                spawnWithCallback(this.settings, ddcutilCall(brightnessIdsIndex+1), nextVcpInfos => ddutilCallback(brightnessIdsIndex+1, nextVcpInfos));
+                                            }
+                                        } else if (vcpInfosArray.length >= 5) {
                                             let display = {};
 
                                             const maxBrightness = vcpInfosArray[4];

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -565,6 +565,13 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                 /* read the current and max brightness using getvcp */
                                 let ddcutilCall = brightnessIdsIndex =>  [ddcutilPath, 'getvcp', '--brief', ddcVcpBrightnessIds[brightnessIdsIndex], '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()];
                                 let ddutilCallback = (brightnessIdsIndex, vcpInfos) => {
+                                    if (vcpInfos.indexOf('Unsupported feature code') !== -1) {
+                                        brightnessIdsIndex++;
+                                        if (brightnessIdsIndex < ddcVcpBrightnessIds.length) {
+                                            spawnWithCallback(this.settings, ddcutilCall(brightnessIdsIndex), vcpInfos => ddutilCallback(brightnessIdsIndex, vcpInfos));
+                                        };
+                                        return;
+                                    }
                                     if (vcpInfos.indexOf('DDC communication failed') === -1 && vcpInfos.indexOf('No monitor detected') === -1) {
                                         const vcpInfosArray = filterVCPInfoSpecification(vcpInfos).split(' ');
                                         if (vcpInfosArray[2] !== 'ERR' && vcpInfosArray.length >= 5) {

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -562,9 +562,10 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                 displayInGoodState = vcpPowerInfosArray.length >= 4 && vcpPowerInfosArray[3] === 'x01';
                             }
                             if (displayInGoodState) {
+                                /* read the current and max brightness using getvcp */
                                 let ddcVcpBrightnessIdsIndex = 0;
-                                let ddcutilCall = brightnessId =>  [ddcutilPath, 'getvcp', '--brief', brightnessId, '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()];                                /* read the current and max brightness using getvcp */
-                                spawnWithCallback(this.settings, ddcutilCall(ddcVcpBrightnessIds[ddcVcpBrightnessIdsIndex]), vcpInfos  => {
+                                let ddcutilCall = brightnessId =>  [ddcutilPath, 'getvcp', '--brief', brightnessId, '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()];
+                                let ddutilCallback = vcpInfos => {
                                     if (vcpInfos.indexOf('DDC communication failed') === -1 && vcpInfos.indexOf('No monitor detected') === -1) {
                                         const vcpInfosArray = filterVCPInfoSpecification(vcpInfos).split(' ');
                                         if (vcpInfosArray[2] !== 'ERR' && vcpInfosArray.length >= 5) {
@@ -582,7 +583,8 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                             this.reloadMenuWidgets();
                                         }
                                     }
-                                });
+                                };
+                                spawnWithCallback(this.settings, ddcutilCall(ddcVcpBrightnessIds[ddcVcpBrightnessIdsIndex]), ddutilCallback);
                             }
                         }
                     });

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -217,8 +217,8 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
         const ddcutilAdditionalArgs = this.settings.get_string('ddcutil-additional-args');
         const sleepMultiplier = this.settings.get_double('ddcutil-sleep-multiplier') / 40;
         const writer = () => {
-            brightnessLog(this.settings, `async ${ddcutilPath} setvcp ${ddcVcpBrightnessId} ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
-            GLib.spawn_command_line_async(`${ddcutilPath} setvcp ${ddcVcpBrightnessId} ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
+            brightnessLog(this.settings, `async ${ddcutilPath} setvcp ${ddcVcpBrightnessIds[0]} ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
+            GLib.spawn_command_line_async(`${ddcutilPath} setvcp ${ddcVcpBrightnessIds[0]} ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
         };
         brightnessLog(this.settings, `display ${display.name}, current: ${display.current} => ${newValue / 100}, new brightness: ${newBrightness}, new value: ${newValue}`);
         display.current = newValue / 100;
@@ -565,7 +565,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                             }
                             if (displayInGoodState) {
                                 /* read the current and max brightness using getvcp */
-                                spawnWithCallback(this.settings, [ddcutilPath, 'getvcp', '--brief', ddcVcpBrightnessId, '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()], vcpInfos  => {
+                                spawnWithCallback(this.settings, [ddcutilPath, 'getvcp', '--brief', ddcVcpBrightnessIds[0], '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()], vcpInfos  => {
                                     if (vcpInfos.indexOf('DDC communication failed') === -1 && vcpInfos.indexOf('No monitor detected') === -1) {
                                         const vcpInfosArray = filterVCPInfoSpecification(vcpInfos).split(' ');
                                         if (vcpInfosArray[2] !== 'ERR' && vcpInfosArray.length >= 5) {

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -564,7 +564,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                             if (displayInGoodState) {
                                 /* read the current and max brightness using getvcp */
                                 let ddcVcpBrightnessIdsIndex = 0;
-                                let ddcutilCall = brightnessId =>  [ddcutilPath, 'getvcp', '--brief', brightnessId, '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()];
+                                let ddcutilCall = brightnessIdsIndex =>  [ddcutilPath, 'getvcp', '--brief', ddcVcpBrightnessIds[brightnessIdsIndex], '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()];
                                 let ddutilCallback = (brightnessIdsIndex, vcpInfos) => {
                                     if (vcpInfos.indexOf('DDC communication failed') === -1 && vcpInfos.indexOf('No monitor detected') === -1) {
                                         const vcpInfosArray = filterVCPInfoSpecification(vcpInfos).split(' ');
@@ -584,7 +584,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                         }
                                     }
                                 };
-                                spawnWithCallback(this.settings, ddcutilCall(ddcVcpBrightnessIds[ddcVcpBrightnessIdsIndex]), vcpInfos => ddutilCallback(ddcVcpBrightnessIdsIndex, vcpInfos));
+                                spawnWithCallback(this.settings, ddcutilCall(ddcVcpBrightnessIdsIndex), vcpInfos => ddutilCallback(ddcVcpBrightnessIdsIndex, vcpInfos));
                             }
                         }
                     });

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -563,8 +563,8 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                             }
                             if (displayInGoodState) {
                                 let ddcVcpBrightnessIdsIndex = 0;
-                                /* read the current and max brightness using getvcp */
-                                spawnWithCallback(this.settings, [ddcutilPath, 'getvcp', '--brief', ddcVcpBrightnessIds[ddcVcpBrightnessIdsIndex], '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()], vcpInfos  => {
+                                let ddcutilCall = brightnessId =>  [ddcutilPath, 'getvcp', '--brief', brightnessId, '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()];                                /* read the current and max brightness using getvcp */
+                                spawnWithCallback(this.settings, ddcutilCall(ddcVcpBrightnessIds[ddcVcpBrightnessIdsIndex]), vcpInfos  => {
                                     if (vcpInfos.indexOf('DDC communication failed') === -1 && vcpInfos.indexOf('No monitor detected') === -1) {
                                         const vcpInfosArray = filterVCPInfoSpecification(vcpInfos).split(' ');
                                         if (vcpInfosArray[2] !== 'ERR' && vcpInfosArray.length >= 5) {

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -215,8 +215,8 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
         const ddcutilAdditionalArgs = this.settings.get_string('ddcutil-additional-args');
         const sleepMultiplier = this.settings.get_double('ddcutil-sleep-multiplier') / 40;
         const writer = () => {
-            brightnessLog(this.settings, `async ${ddcutilPath} setvcp ${ddcVcpBrightnessIds[0]} ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
-            GLib.spawn_command_line_async(`${ddcutilPath} setvcp ${ddcVcpBrightnessIds[0]} ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
+            brightnessLog(this.settings, `async ${ddcutilPath} setvcp ${display.vcpId} ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
+            GLib.spawn_command_line_async(`${ddcutilPath} setvcp ${display.vcpId} ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
         };
         brightnessLog(this.settings, `display ${display.name}, current: ${display.current} => ${newValue / 100}, new brightness: ${newBrightness}, new value: ${newValue}`);
         display.current = newValue / 100;

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -67,6 +67,9 @@ let syncing = false
 let pause_sync = false
 let internal_control = true
 
+//const ddcVcpBrightnessId = '10';
+const ddcVcpBrightnessId = '6B';
+
 /*
     instead of reading i2c bus everytime during startup,
     as it is unlikely that bus number changes, we can read
@@ -209,8 +212,8 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
         const ddcutilAdditionalArgs = this.settings.get_string('ddcutil-additional-args');
         const sleepMultiplier = this.settings.get_double('ddcutil-sleep-multiplier') / 40;
         const writer = () => {
-            brightnessLog(this.settings, `async ${ddcutilPath} setvcp 10 ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
-            GLib.spawn_command_line_async(`${ddcutilPath} setvcp 10 ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
+            brightnessLog(this.settings, `async ${ddcutilPath} setvcp ${ddcVcpBrightnessId} ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
+            GLib.spawn_command_line_async(`${ddcutilPath} setvcp ${ddcVcpBrightnessId} ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`);
         };
         brightnessLog(this.settings, `display ${display.name}, current: ${display.current} => ${newValue / 100}, new brightness: ${newBrightness}, new value: ${newValue}`);
         display.current = newValue / 100;
@@ -556,8 +559,8 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                 displayInGoodState = vcpPowerInfosArray.length >= 4 && vcpPowerInfosArray[3] === 'x01';
                             }
                             if (displayInGoodState) {
-                                /* read the current and max brightness using getvcp 10 */
-                                spawnWithCallback(this.settings, [ddcutilPath, 'getvcp', '--brief', '10', '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()], vcpInfos  => {
+                                /* read the current and max brightness using getvcp */
+                                spawnWithCallback(this.settings, [ddcutilPath, 'getvcp', '--brief', ddcVcpBrightnessId, '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()], vcpInfos  => {
                                     if (vcpInfos.indexOf('DDC communication failed') === -1 && vcpInfos.indexOf('No monitor detected') === -1) {
                                         const vcpInfosArray = filterVCPInfoSpecification(vcpInfos).split(' ');
                                         if (vcpInfosArray[2] !== 'ERR' && vcpInfosArray.length >= 5) {

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -562,8 +562,9 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                 displayInGoodState = vcpPowerInfosArray.length >= 4 && vcpPowerInfosArray[3] === 'x01';
                             }
                             if (displayInGoodState) {
+                                let ddcVcpBrightnessIdsIndex = 0;
                                 /* read the current and max brightness using getvcp */
-                                spawnWithCallback(this.settings, [ddcutilPath, 'getvcp', '--brief', ddcVcpBrightnessIds[0], '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()], vcpInfos  => {
+                                spawnWithCallback(this.settings, [ddcutilPath, 'getvcp', '--brief', ddcVcpBrightnessIds[ddcVcpBrightnessIdsIndex], '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()], vcpInfos  => {
                                     if (vcpInfos.indexOf('DDC communication failed') === -1 && vcpInfos.indexOf('No monitor detected') === -1) {
                                         const vcpInfosArray = filterVCPInfoSpecification(vcpInfos).split(' ');
                                         if (vcpInfosArray[2] !== 'ERR' && vcpInfosArray.length >= 5) {
@@ -574,7 +575,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                             const currentBrightness = vcpInfosArray[3] / vcpInfosArray[4];
 
                                             /* make display object */
-                                            display = {'bus': displayBus, 'max': maxBrightness, 'current': currentBrightness, 'name': displayNames[displayId], 'vcpId': ddcVcpBrightnessIds[0]};
+                                            display = {'bus': displayBus, 'max': maxBrightness, 'current': currentBrightness, 'name': displayNames[displayId], 'vcpId': ddcVcpBrightnessIds[ddcVcpBrightnessIdsIndex]};
                                             displays.push(display);
 
                                             /* cheap way of making reloading all display slider in the panel */

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -563,7 +563,6 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                             }
                             if (displayInGoodState) {
                                 /* read the current and max brightness using getvcp */
-                                let ddcVcpBrightnessIdsIndex = 0;
                                 let ddcutilCall = brightnessIdsIndex =>  [ddcutilPath, 'getvcp', '--brief', ddcVcpBrightnessIds[brightnessIdsIndex], '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()];
                                 let ddutilCallback = (brightnessIdsIndex, vcpInfos) => {
                                     if (vcpInfos.indexOf('DDC communication failed') === -1 && vcpInfos.indexOf('No monitor detected') === -1) {
@@ -576,7 +575,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                             const currentBrightness = vcpInfosArray[3] / vcpInfosArray[4];
 
                                             /* make display object */
-                                            display = {'bus': displayBus, 'max': maxBrightness, 'current': currentBrightness, 'name': displayNames[displayId], 'vcpId': ddcVcpBrightnessIds[ddcVcpBrightnessIdsIndex]};
+                                            display = {'bus': displayBus, 'max': maxBrightness, 'current': currentBrightness, 'name': displayNames[displayId], 'vcpId': ddcVcpBrightnessIds[brightnessIdsIndex]};
                                             displays.push(display);
 
                                             /* cheap way of making reloading all display slider in the panel */
@@ -584,7 +583,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                         }
                                     }
                                 };
-                                spawnWithCallback(this.settings, ddcutilCall(ddcVcpBrightnessIdsIndex), vcpInfos => ddutilCallback(ddcVcpBrightnessIdsIndex, vcpInfos));
+                                spawnWithCallback(this.settings, ddcutilCall(0), vcpInfos => ddutilCallback(0, vcpInfos));
                             }
                         }
                     });

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -69,6 +69,11 @@ let internal_control = true
 
 //const ddcVcpBrightnessId = '10';
 const ddcVcpBrightnessId = '6B';
+const ddcVcpBrightnessIds = [
+    //'fa',    // Non-existant; used to test fallback works
+    '6B',      // Backlight Level: White
+    '10',      // Brightness
+];
 
 /*
     instead of reading i2c bus everytime during startup,

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -67,8 +67,6 @@ let syncing = false
 let pause_sync = false
 let internal_control = true
 
-//const ddcVcpBrightnessId = '10';
-const ddcVcpBrightnessId = '6B';
 const ddcVcpBrightnessIds = [
     //'fa',    // Non-existant; used to test fallback works
     '6B',      // Backlight Level: White
@@ -576,7 +574,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                             const currentBrightness = vcpInfosArray[3] / vcpInfosArray[4];
 
                                             /* make display object */
-                                            display = {'bus': displayBus, 'max': maxBrightness, 'current': currentBrightness, 'name': displayNames[displayId]};
+                                            display = {'bus': displayBus, 'max': maxBrightness, 'current': currentBrightness, 'name': displayNames[displayId], 'vcpId': ddcVcpBrightnessIds[0]};
                                             displays.push(display);
 
                                             /* cheap way of making reloading all display slider in the panel */

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -565,7 +565,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                 /* read the current and max brightness using getvcp */
                                 let ddcVcpBrightnessIdsIndex = 0;
                                 let ddcutilCall = brightnessId =>  [ddcutilPath, 'getvcp', '--brief', brightnessId, '--bus', displayBus, '--sleep-multiplier', sleepMultiplier.toString()];
-                                let ddutilCallback = vcpInfos => {
+                                let ddutilCallback = (brightnessIdsIndex, vcpInfos) => {
                                     if (vcpInfos.indexOf('DDC communication failed') === -1 && vcpInfos.indexOf('No monitor detected') === -1) {
                                         const vcpInfosArray = filterVCPInfoSpecification(vcpInfos).split(' ');
                                         if (vcpInfosArray[2] !== 'ERR' && vcpInfosArray.length >= 5) {
@@ -584,7 +584,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                                         }
                                     }
                                 };
-                                spawnWithCallback(this.settings, ddcutilCall(ddcVcpBrightnessIds[ddcVcpBrightnessIdsIndex]), ddutilCallback);
+                                spawnWithCallback(this.settings, ddcutilCall(ddcVcpBrightnessIds[ddcVcpBrightnessIdsIndex]), vcpInfos => ddutilCallback(ddcVcpBrightnessIdsIndex, vcpInfos));
                             }
                         }
                     });


### PR DESCRIPTION
On the Fujitsu B19-7 LED (and probably others) the brightness controls on the monitor control the "VCP Feature 6B (Backlight Level: White)". While "VCP Feature 10 (Brightness)" exists, changing it looks ugly and destroys the contrast and is best left unchanged at 50.

This pull request creates a list of the VCP IDs with currently two items that control the brightness. When getting the current and max brightness of the display it tries the VPC IDs in sequential order and saves the first not giving an ERR in the display object. Other ddcutil calls that before this pull request used the "VCP Feature 10 (Brightness)" now use the VPC ID stored in the display object.