### PR TITLE
Update stylesheet.css (fixes issue #142: Too much padding between display name and slider)

### DIFF
--- a/display-brightness-ddcutil@themightydeity.github.com/stylesheet.css
+++ b/display-brightness-ddcutil@themightydeity.github.com/stylesheet.css
@@ -1,6 +1,6 @@
 .display-brightness-ddcutil-monitor-name-system-menu {
     width: auto; max-width: 60px;
-    overflow: none;
+    overflow: hidden;
     padding: 0px !important;
     margin: 0px !important;
 }

--- a/display-brightness-ddcutil@themightydeity.github.com/stylesheet.css
+++ b/display-brightness-ddcutil@themightydeity.github.com/stylesheet.css
@@ -1,5 +1,5 @@
 .display-brightness-ddcutil-monitor-name-system-menu {
-    max-width: 60px;
+    width: auto; max-width: 60px;
     overflow: none;
     padding: 0px !important;
     margin: 0px !important;

--- a/display-brightness-ddcutil@themightydeity.github.com/stylesheet.css
+++ b/display-brightness-ddcutil@themightydeity.github.com/stylesheet.css
@@ -1,5 +1,5 @@
 .display-brightness-ddcutil-monitor-name-system-menu {
-    width: auto;
+    max-width: 60px;
     overflow: none;
     padding: 0px !important;
     margin: 0px !important;

--- a/display-brightness-ddcutil@themightydeity.github.com/stylesheet.css
+++ b/display-brightness-ddcutil@themightydeity.github.com/stylesheet.css
@@ -1,6 +1,9 @@
 .display-brightness-ddcutil-monitor-name-system-menu {
     width: auto; max-width: 60px;
-    overflow: hidden;
+    /*"max-width" is a valid property on Ubuntu 24.04.1 LTS with Gnome 46 (tested OK!)*/
+    /*"overflow: hidden" is not supported in GTK-CSS... It could only be implemented
+    this way: https://docs.gtk.org/gtk4/enum.Overflow.html 
+    It's already set to "hidden", somehow somewhere, anyway. :) */
     padding: 0px !important;
     margin: 0px !important;
 }

--- a/display-brightness-ddcutil@themightydeity.github.com/stylesheet.css
+++ b/display-brightness-ddcutil@themightydeity.github.com/stylesheet.css
@@ -1,5 +1,5 @@
-.display-brightness-ddcutil-monitor-name-system-menu{
-    width: 60px;
+.display-brightness-ddcutil-monitor-name-system-menu {
+    width: auto;
     overflow: none;
     padding: 0px !important;
     margin: 0px !important;


### PR DESCRIPTION
Fixes issue #142 
The monitor-name-system-menu should not be a fixed width. It looks really bad when the name is just "P27", for example.

before:
![display-brightness-ddcutil-old](https://github.com/user-attachments/assets/14b0d1a9-2796-465d-b9ff-28f1dd612c90)

after:
![display-brightness-ddcutil-new](https://github.com/user-attachments/assets/53704f70-4f1c-4627-b1eb-f09695b895bb)