### PR TITLE
Feature configure brightness ids

### DIFF
--- a/display-brightness-ddcutil@themightydeity.github.com/po/de.po
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-09 01:21+0300\n"
+"POT-Creation-Date: 2024-10-17 23:27+0200\n"
 "PO-Revision-Date: 2022-02-13 09:53+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -27,12 +27,10 @@ msgid "Enable \"All\" Slider"
 msgstr "Gemeinsamen Schieberegler anzeigen"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:14
-#, fuzzy
 msgid "Enable \"Internal\" Slider"
-msgstr "Gemeinsamen Schieberegler anzeigen"
+msgstr "Internen Schieberegler anzeigen"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:19
-#, fuzzy
 msgid "Use Only \"All\" Slider"
 msgstr "Nur gemeinsame Regler anzeigen"
 
@@ -61,9 +59,8 @@ msgid "Hide System Indicator"
 msgstr "Systemindikator verstecken"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:57
-#, fuzzy
 msgid "Position in System Indicator"
-msgstr "Systemindikator verstecken"
+msgstr "Position des Systemindikators"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:65
 msgid "Position in System Menu"
@@ -106,37 +103,46 @@ msgid "`ddcutil` Queue ms"
 msgstr ""
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:139
-#, fuzzy
 msgid "Allow Zero Brightness"
 msgstr "Vollständige Abdunkelung erlauben"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:144
-#, fuzzy
-msgid "Disable Display State Check"
-msgstr "Status-Überprüfung deaktivieren"
+msgid "DDC VCP Brightness Ids"
+msgstr "DDC VCP Helligkeits Ids"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:145
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:147
+msgid "Backlight Level: White (6B)"
+msgstr "Hintergrund-Helligkeit: Weiß (6B) "
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:153
+msgid "Brightness (10)"
+msgstr "Helligkeit (10)"
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:161
+msgid "Disable Display State Check"
+msgstr "Status-Überprüfung Bildschrim deaktivieren"
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:162
 msgid ""
 "Disables the check for the display power state before changing brightness, "
 "might help in detecting more displays"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:150
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:167
 msgid "Verbose debugging"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:158
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:175
 msgid "Top Bar"
 msgstr "Obere Leiste"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:159
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:176
 msgid "System Menu"
 msgstr "System-Menü"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/shortcut.ui:11
-#, fuzzy
 msgid "Set Shortcut…"
-msgstr "Tastaturkurzbefehle"
+msgstr "Tastaturkurzbefehle setzen"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/shortcut.ui:65
 msgid "Add Custom Shortcut"

--- a/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-16 00:28+0300\n"
+"POT-Creation-Date: 2024-10-17 23:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -106,24 +106,36 @@ msgid "Allow Zero Brightness"
 msgstr ""
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:144
+msgid "DDC VCP Brightness Ids"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:147
+msgid "Backlight Level: White (6B)"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:153
+msgid "Brightness (10)"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:161
 msgid "Disable Display State Check"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:145
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:162
 msgid ""
 "Disables the check for the display power state before changing brightness, "
 "might help in detecting more displays"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:150
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:167
 msgid "Verbose debugging"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:158
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:175
 msgid "Top Bar"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:159
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:176
 msgid "System Menu"
 msgstr ""
 

--- a/display-brightness-ddcutil@themightydeity.github.com/po/es.po
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-display-brightness-ddcutil\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-09 01:21+0300\n"
+"POT-Creation-Date: 2024-10-17 23:27+0200\n"
 "PO-Revision-Date: 2023-11-26 12:05+0100\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@tuta.io>\n"
 "Language-Team: Spanish\n"
@@ -108,24 +108,36 @@ msgid "Allow Zero Brightness"
 msgstr "Permitir brillo cero"
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:144
+msgid "DDC VCP Brightness Ids"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:147
+msgid "Backlight Level: White (6B)"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:153
+msgid "Brightness (10)"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:161
 msgid "Disable Display State Check"
 msgstr "Desactivar la comprobación del estado de la pantalla"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:145
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:162
 msgid ""
 "Disables the check for the display power state before changing brightness, "
 "might help in detecting more displays"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:150
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:167
 msgid "Verbose debugging"
 msgstr "Depuración detallada"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:158
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:175
 msgid "Top Bar"
 msgstr "Barra superior"
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:159
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:176
 msgid "System Menu"
 msgstr "Menú del sistema"
 

--- a/display-brightness-ddcutil@themightydeity.github.com/prefs.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/prefs.js
@@ -29,6 +29,8 @@ const PrefsWidget = GObject.registerClass({
         'queue_ms_row',
         'ddcutil_additional_args_row',
         'allow_zero_brightness_row',
+        'try_ddc_vcp_backlight_level_white_6b',
+        'try_ddc_vcp_brightness_10',
         'disable_display_state_check_row',
         'verbose_debugging_row',
     ],
@@ -128,6 +130,8 @@ const PrefsWidget = GObject.registerClass({
             Gio.SettingsBindFlags.DEFAULT
         );
 
+        this.settings.connect('changed::ddc-vcp-brightness-ids', () => this._readDdcVcpBrightnessIds());
+        this._readDdcVcpBrightnessIds();
 
         this.settings.connect('changed::increase-brightness-shortcut', () => {
             this._increase_shortcut_button.keybinding = this.settings.get_strv('increase-brightness-shortcut')[0];
@@ -149,6 +153,21 @@ const PrefsWidget = GObject.registerClass({
         this.settings.connect('changed::hide-system-indicator', () => {
             this._position_system_indicator_row.sensitive = !this.settings.get_boolean('hide-system-indicator');
         });
+    }
+
+    _readDdcVcpBrightnessIds() {
+        let brightness_ids = this.settings.get_strv('ddc-vcp-brightness-ids');
+        this._try_ddc_vcp_backlight_level_white_6b.active = brightness_ids.includes('6B');
+        this._try_ddc_vcp_brightness_10.active = brightness_ids.includes('10');
+
+    }
+
+    onDdcVcpBrightnessIdsChanged() {
+        let brightness_ids = [
+            this._try_ddc_vcp_backlight_level_white_6b.active ? '6B' : undefined,
+            this._try_ddc_vcp_brightness_10.active ? '10' : undefined,
+        ].filter(v => v !== undefined);
+        this.settings.set_strv('ddc-vcp-brightness-ids', brightness_ids);
     }
 
     onButtonLocationChanged() {

--- a/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
+++ b/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
@@ -84,6 +84,15 @@
       <default>false</default>
       <summary>Allow zero brightness</summary>
     </key>
+    <key type="as" name="ddc-vcp-brightness-ids">
+      <default><![CDATA[['10']]]></default>
+      <summary>
+        The DDC VCP Brightness Ids to use in descending order of priority.
+        Common IDs are "Backlight Level: White (6B)" and "Brightness (10)".
+        IDs that a monitor does not support will be skipped and the next in the
+        list we be tried.
+      </summary>
+    </key>
     <key type="b" name="disable-display-state-check">
       <default>false</default>
       <summary>Disable display state check</summary>

--- a/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
@@ -140,6 +140,23 @@
           </object>
         </child>
         <child>
+          <object class="AdwExpanderRow">
+            <property name="title" translatable="yes">DDC VCP Brightness Ids</property>
+            <child>
+              <object class="AdwSwitchRow" id="try_ddc_vcp_backlight_level_white_6b">
+                <property name="title" translatable="yes">Backlight Level: White (6B)</property>
+                <signal name="notify::active" handler="onDdcVcpBrightnessIdsChanged" swapped="no" />
+              </object>
+            </child>
+            <child>
+              <object class="AdwSwitchRow" id="try_ddc_vcp_brightness_10">
+                <property name="title" translatable="yes">Brightness (10)</property>
+                <signal name="notify::active" handler="onDdcVcpBrightnessIdsChanged" swapped="no" />
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
           <object class="AdwSwitchRow" id="disable_display_state_check_row">
             <property name="title" translatable="yes">Disable Display State Check</property>
             <property name="subtitle" translatable="yes">Disables the check for the display power state before changing brightness, might help in detecting more displays</property>


### PR DESCRIPTION
This allows the user to configure which of the two DDC VCP brightness ids are tried.

from https://github.com/daitj/gnome-display-brightness-ddcutil/pull/152:

"It would be better to have it stored in the settings instead as a list, I haven't had time to figure that out. A dropdown list perhaps with multiselect values, 10 is selected and has 6B unselected. If you have time to do those then it would be easy to merge" – Binay Devkota

Thank you for merging it anyways. Personally, I'm not convinced that this being configurable is necessary or desirable. So if you happened to have changed your mind, feel free to drop this merge request. No hard feelings.
                                                                                                                             
    