### PR TITLE
OpenSUSE Aeon i2c Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ ddcutil 2.0+
 sudo cp /usr/share/ddcutil/data/60-ddcutil-i2c.rules /etc/udev/rules.d
 
 ```
-**Note: Fedora 40+ users, you need to uncomment this line**
+**Note: Fedora 40+ and OpenSUSE Aeon users, you need to uncomment this line**
 ```
 # KERNEL=="i2c-[0-9]*", GROUP="i2c", MODE="0660"
 ```


### PR DESCRIPTION
# KERNEL=="i2c-[0-9]*", GROUP="i2c", MODE="0660"

The above line also needs to be uncommented when using OpenSUSE Aeon, I have not tested this on other OpenSUSE distros, but it may also be the case.