### PR TITLE
Feature: Contrast slider [VCP 12]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ build: schemas
 	gnome-extensions pack \
 		--force \
 		--extra-source=ui \
+		--extra-source=icons \
 		--extra-source=convenienceExt.js \
 		--extra-source=conveniencePref.js \
 		--extra-source=indicator.js \

--- a/display-brightness-ddcutil@themightydeity.github.com/convenienceExt.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/convenienceExt.js
@@ -5,9 +5,9 @@ export function isNullOrWhitespace(str) {
 }
 
 /**
- * 
- * @param {*} settings 
- * @param {*} str 
+ *
+ * @param {*} settings
+ * @param {*} str
  */
 export function brightnessLog(settings, ...args) {
     if (settings.get_boolean('verbose-debugging'))
@@ -32,11 +32,11 @@ export async function spawnWithCallback(settings, argv, callback) {
                     await callback(stderr);
                 else if (stdout)
                     await callback(stdout);
-                else 
+                else
                     await callback("");
             }
         });
-        
+
     } catch (e) {
         brightnessLog(settings, e);
     }

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -225,24 +225,25 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
             return
         syncing = true
         if (this.settings.get_boolean('show-all-slider')) {
+            const brightnessDisplays = displays.filter(d => d.type === 'brightness')
             var sum = 0.0
-            for (let display of displays) {
+            for (let display of brightnessDisplays) {
                 sum = sum + display.slider.ValueSlider.value
             }
-            mainMenuButton.getStoredSliders()[0].changeValue(sum * 100 / displays.length)
-            mainMenuButton.getStoredSliders()[0].old_value = sum * 100 / displays.length;
+            mainMenuButton.getStoredSliders()[0].changeValue(sum * 100 / brightnessDisplays.length)
+            mainMenuButton.getStoredSliders()[0].old_value = sum * 100 / brightnessDisplays.length;
         }
         syncing = false
     }
 
     setAllBrightness(newValue) {
-
         if (syncing)
             return
         pause_sync = true
+        const brightnessDisplays = displays.filter(d => d.type === 'brightness')
         const mode = "experimental"
         if (mode === "original") {
-            displays.forEach(display => {
+            brightnessDisplays.forEach(display => {
                 display.slider.setHideOSD();
                 display.slider.changeValue(newValue);
                 display.slider.resetOSD();
@@ -258,7 +259,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                 const increase = newValue - oldValue
                 const remaining = 100 - oldValue
                 const frac = increase / remaining
-                displays.forEach(display => {
+                brightnessDisplays.forEach(display => {
                     display.slider.setHideOSD();
                     const oldValue = 100 * display.slider.ValueSlider.value;
                     const remaining = 100 - oldValue
@@ -270,7 +271,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                 const decrease = oldValue - newValue
                 const remaining = oldValue
                 const frac = decrease / remaining
-                displays.forEach(display => {
+                brightnessDisplays.forEach(display => {
                     display.slider.setHideOSD();
                     const oldValue = 100 * display.slider.ValueSlider.value;
                     const remaining = oldValue
@@ -312,12 +313,12 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
         };
         let allslider = null;
         if (this.settings.get_int('button-location') === 0) {
-            allslider = new SingleMonitorSliderAndValueForStatusAreaMenu(this.settings, _('All'), displays[0].current, onAllSliderChange);
+            allslider = new SingleMonitorSliderAndValueForStatusAreaMenu(this.settings, _('All'), displays.find(d => d.type === 'brightness').current, onAllSliderChange);
         } else {
             allslider = new SingleMonitorSliderAndValueForQuickSettings({
                 settings: this.settings,
                 'display-name': _('All'),
-                'current-value': displays[0].current,
+                'current-value': displays.find(d => d.type === 'brightness').current,
             });
             allslider.connect('slider-change', onAllSliderChange);
             if (this.settings.get_boolean('show-sliders-in-submenu'))
@@ -335,14 +336,18 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
             this.setBrightness(display, newValue);
             this.syncAllSlider();
         };
+        const iconName = display.type === 'contrast'
+            ? `${this.path}/icons/contrast-symbolic.svg`
+            : 'display-brightness-symbolic';
         let displaySlider = null;
         if (this.settings.get_int('button-location') === 0) {
-            displaySlider = new SingleMonitorSliderAndValueForStatusAreaMenu(this.settings, display.name, display.current, onSliderChange);
+            displaySlider = new SingleMonitorSliderAndValueForStatusAreaMenu(this.settings, display.name, display.current, onSliderChange, iconName);
         } else if (this.settings.get_boolean('show-sliders-in-submenu')) {
             displaySlider = new SingleMonitorSliderAndValueForQuickSettingsSubMenu({
                 settings: this.settings,
                 'display-name': display.name,
-                'current-value': display.current
+                'current-value': display.current,
+                'icon-name': iconName,
             });
             displaySlider.connect('slider-change', onSliderChange);
         } else {
@@ -350,6 +355,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                 settings: this.settings,
                 'display-name': display.name,
                 'current-value': display.current,
+                'icon-name': iconName,
             });
             displaySlider.connect('slider-change', onSliderChange);
         }
@@ -421,6 +427,16 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
             if (this.settings.get_boolean('show-all-slider'))
                 this.addAllSlider();
 
+            displays.sort((a, b) => {
+                if (a.bus === 'internal') return -1;
+                if (b.bus === 'internal') return 1;
+                const busA = parseInt(a.bus);
+                const busB = parseInt(b.bus);
+                if (busA !== busB) return busA - busB;
+                if (a.type === 'brightness' && b.type !== 'brightness') return -1;
+                if (a.type !== 'brightness' && b.type === 'brightness') return 1;
+                return 0;
+            });
             displays.forEach(display => {
                 this.addDisplayToPanel(display);
             });
@@ -441,7 +457,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                     but we want custom positioning, this is bit of a hack to access
                     _grid (St.Widget) directly and add items there,
                 */
-                mainMenuButton.quickSettingsItems.forEach(item => {
+                [...mainMenuButton.quickSettingsItems].reverse().forEach(item => {
                     /*
                         also for Label and Name we are accessing slider's parent's parent
                         Slider->Parent(St.Bin)->Parent(St.BoxLayout)
@@ -535,13 +551,13 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
         return (ddcutilResponseArray[2] === 'ERR')
     }
 
-    afterGetDdcutilBrightnessResponseSuccess(displayBus, displayName, vcp, ddcutilResponseArray) {
+    afterGetDdcutilBrightnessResponseSuccess(type, displayBus, displayName, vcp, ddcutilResponseArray) {
         let display = {};
         const maxBrightness = ddcutilResponseArray[4];
         /* we need current brightness in the scale of 0 to 1 for slider*/
         const currentBrightness = ddcutilResponseArray[3] / ddcutilResponseArray[4];
         /* make display object */
-        display = { 'bus': displayBus, 'max': maxBrightness, 'current': currentBrightness, 'name': displayName, 'vcp': vcp };
+        display = {'type': type, 'bus': displayBus, 'max': maxBrightness, 'current': currentBrightness, 'name': displayName, 'vcp': vcp };
         brightnessLog(this.settings, `added display to list ${JSON.stringify(display)}`);
         displays.push(display);
 
@@ -574,7 +590,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                 const ddcutilResponseArray = getVCPInfoAsArray(ddcutilResponse)
                 if (ddcutilResponseArray.length >= 5) {
                     brightnessLog(this.settings, `ddcutil getvcp ${vcpList[vcpListIndex]} got success response for bus ${displayBus}`);
-                    this.afterGetDdcutilBrightnessResponseSuccess(displayBus, displayName, vcpList[vcpListIndex], ddcutilResponseArray)
+                    this.afterGetDdcutilBrightnessResponseSuccess('brightness', displayBus, displayName, vcpList[vcpListIndex], ddcutilResponseArray)
                 }
             }
         }
@@ -585,7 +601,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
             let proxy = new BrightnessProxy(Gio.DBus.session, BUS_NAME, OBJECT_PATH);
             let current = proxy.Brightness / 100
 
-            let display = {'bus': 'internal', 'max': 100, 'current': current, 'name': _('Internal')}
+            let display = {'type': 'brightness', 'bus': 'internal', 'max': 100, 'current': current, 'name': _('Internal')}
             if (Number.isInteger(current) && current >= 0)
                 displays.push(display)
         }
@@ -635,6 +651,22 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                 // start with an ERR, so that the getDdcutilResponse will directly call
                 // move to call with index 0
                 await this.getDdcutilResponse(displayBus, displayName, -1, "VCP 0 ERR")
+
+                if (this.settings.get_boolean('vcp-12')) {
+                    await this.addContrastDisplayIfSupported(displayBus, displayName)
+                }
+            }
+        });
+    }
+
+    async addContrastDisplayIfSupported(displayBus, displayName) {
+        await this.ddcutilCommandLine('12', displayBus, async ddcutilResponse => {
+            brightnessLog(this.settings, `ddcutil getvcp 12 (contrast) for bus ${displayBus}: ${ddcutilResponse.replace(/\n+$/, '')}`);
+            if (this.displayValidate(ddcutilResponse) && !this.displayResponseError(ddcutilResponse)) {
+                const ddcutilResponseArray = getVCPInfoAsArray(ddcutilResponse)
+                if (ddcutilResponseArray.length >= 5) {
+                    this.afterGetDdcutilBrightnessResponseSuccess('contrast', displayBus, displayName, '12', ddcutilResponseArray)
+                }
             }
         });
     }
@@ -673,6 +705,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
             'show-sliders-in-submenu': this.settings.get_boolean('show-sliders-in-submenu'),
             'vcp-6b': this.settings.get_boolean('vcp-6b'),
             'vcp-10': this.settings.get_boolean('vcp-10'),
+            'vcp-12': this.settings.get_boolean('vcp-12'),
             'verbose-debugging': this.settings.get_boolean('verbose-debugging'),
             'ddcutil-sleep-multiplier': this.settings.get_double('ddcutil-sleep-multiplier'),
             'position-system-indicator': this.settings.get_double('position-system-indicator'),
@@ -726,6 +759,9 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
                 this.reloadExtension();
             }),
             vcp10: this.settings.connect('changed::vcp-10', () => {
+                this.reloadExtension();
+            }),
+            vcp12: this.settings.connect('changed::vcp-12', () => {
                 this.reloadExtension();
             }),
             indicator: this.settings.connect('changed::button-location', () => {

--- a/display-brightness-ddcutil@themightydeity.github.com/icons/contrast-symbolic.svg
+++ b/display-brightness-ddcutil@themightydeity.github.com/icons/contrast-symbolic.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg height="16px" viewBox="0 0 16 16" width="16px" xmlns="http://www.w3.org/2000/svg">
+  <!-- Left half: filled solid D-shape -->
+  <path d="M 8 3 A 5 5 0 0 0 8 13 Z" fill="#2e3436"/>
+  <!-- Right half: ring (outer radius 5, inner radius 3, thickness 2px) -->
+  <path d="M 8 3 A 5 5 0 0 1 8 13 L 8 11 A 3 3 0 0 0 8 5 Z" fill="#2e3436"/>
+</svg>

--- a/display-brightness-ddcutil@themightydeity.github.com/indicator.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/indicator.js
@@ -39,7 +39,7 @@ function sliderKeyUpDownEvent(actor, settings, direction) {
     actor.getStoredSliders().forEach(slider => {
         slider.setShowOSD();
         const nextValue = Math.min(Math.max(0, slider.ValueSlider.value + step), slider.ValueSlider._maxValue)
-        brightnessLog(settings, 
+        brightnessLog(settings,
             `Slider key up or down, direction:${direction} step:${step}, current:${slider.ValueSlider.value} => ${nextValue}`
         )
         slider.ValueSlider.value = nextValue;
@@ -77,10 +77,10 @@ function sliderValueChangeCommon(item) {
         }
 
         Main.osdWindowManager.show(
-            new Gio.ThemedIcon({name: 'display-brightness-symbolic'}), 
+            new Gio.ThemedIcon({name: 'display-brightness-symbolic'}),
             osdLabel,
-            Array.from({ 
-                length: Main.layoutManager.monitors.length 
+            Array.from({
+                length: Main.layoutManager.monitors.length
             }, () => (
                 { level: item.ValueSlider.value, maxLevel: 1 })
             )
@@ -203,7 +203,7 @@ export const SingleMonitorMenuItem = GObject.registerClass({
     _init(settings, icon, name, slider, label) {
         super._init();
         if (icon != null)
-            this.add_actor(icon);
+            this.add_child(icon);
 
         if (name != null && settings.get_boolean('show-display-name'))
             this.add_child(name);
@@ -216,7 +216,7 @@ export const SingleMonitorMenuItem = GObject.registerClass({
 });
 
 export const SingleMonitorSliderAndValueForStatusAreaMenu = class SingleMonitorSliderAndValue extends PopupMenu.PopupMenuSection {
-    constructor(settings, displayName, currentValue, onSliderChange) {
+    constructor(settings, displayName, currentValue, onSliderChange, iconName = 'display-brightness-symbolic') {
         super();
         this._settings = settings;
         this._displayName = displayName;
@@ -225,6 +225,7 @@ export const SingleMonitorSliderAndValueForStatusAreaMenu = class SingleMonitorS
         /* OSD is never shown by default */
         this._hideOSD = true;
         this.__hideOSDBackup = true;
+        this._iconName = iconName;
         this._init();
     }
 
@@ -245,7 +246,10 @@ export const SingleMonitorSliderAndValueForStatusAreaMenu = class SingleMonitorS
             x_expand: true,
             y_align: Clutter.ActorAlign.CENTER,
         });
-        this.SliderContainer = new SingleMonitorMenuItem(this._settings, null, null, valueSliderBin, this.ValueLabel);
+        const icon = this._iconName.startsWith('/')
+            ? new St.Icon({gicon: Gio.FileIcon.new(Gio.File.new_for_path(this._iconName)), style_class: 'popup-menu-icon'})
+            : new St.Icon({icon_name: this._iconName, style_class: 'popup-menu-icon'});
+        this.SliderContainer = new SingleMonitorMenuItem(this._settings, icon, null, valueSliderBin, this.ValueLabel);
         if (this._settings.get_boolean('show-display-name'))
             this.addMenuItem(this.NameContainer);
 
@@ -272,7 +276,7 @@ export const SingleMonitorSliderAndValueForStatusAreaMenu = class SingleMonitorS
     }
 
     _SliderChange() {
-        brightnessLog(this._settings, `StatusArea _SliderChange event ${this.ValueSlider.value}`) 
+        brightnessLog(this._settings, `StatusArea _SliderChange event ${this.ValueSlider.value}`)
         sliderValueChangeCommon(this);
     }
 };
@@ -289,6 +293,9 @@ export const SingleMonitorSliderAndValueForQuickSettingsSubMenu = GObject.regist
         'current-value': GObject.ParamSpec.double('current-value', 'current-value', 'current-value',
             GObject.ParamFlags.READWRITE,
             0, 1, 1),
+        'icon-name': GObject.ParamSpec.string('icon-name', 'icon-name', 'icon-name',
+            GObject.ParamFlags.READWRITE,
+            'display-brightness-symbolic'),
     },
     Signals: {
         'slider-change': {
@@ -297,9 +304,12 @@ export const SingleMonitorSliderAndValueForQuickSettingsSubMenu = GObject.regist
     },
 }, class SingleMonitorSliderAndValueForQuickSettingsSubMenu extends PopupMenu.PopupImageMenuItem {
     _init(params) {
+        const iconParam = params['icon-name'] ?? 'display-brightness-symbolic';
         super._init(
-            "", 'display-brightness-symbolic', {}
+            "", iconParam.startsWith('/') ? 'display-brightness-symbolic' : iconParam, {}
         );
+        if (iconParam.startsWith('/') && this._icon)
+            this._icon.gicon = Gio.FileIcon.new(Gio.File.new_for_path(iconParam));
         this.settings = params.settings
         this.display_name = params['display-name']
         this.current_value = params['current-value']
@@ -351,7 +361,7 @@ export const SingleMonitorSliderAndValueForQuickSettingsSubMenu = GObject.regist
     }
 
     _SliderChange() {
-        brightnessLog(this._settings, `QuickSettings submenu _SliderChange event ${this.ValueSlider.value}`) 
+        brightnessLog(this._settings, `QuickSettings submenu _SliderChange event ${this.ValueSlider.value}`)
         sliderValueChangeCommon(this);
     }
 });
@@ -369,6 +379,9 @@ export const SingleMonitorSliderAndValueForQuickSettings = GObject.registerClass
         'current-value': GObject.ParamSpec.double('current-value', 'current-value', 'current-value',
             GObject.ParamFlags.READWRITE,
             0, 1, 1),
+        'icon-name': GObject.ParamSpec.string('icon-name', 'icon-name', 'icon-name',
+            GObject.ParamFlags.READWRITE,
+            'display-brightness-symbolic'),
     },
     Signals: {
         'slider-change': {
@@ -377,10 +390,13 @@ export const SingleMonitorSliderAndValueForQuickSettings = GObject.registerClass
     },
 }, class SingleMonitorSliderAndValueForQuickSettings extends QuickSettings.QuickSlider {
     _init(params) {
+        const iconParam = params['icon-name'] ?? 'display-brightness-symbolic';
         super._init({
             ...params,
-            iconName: 'display-brightness-symbolic',
+            iconName: iconParam.startsWith('/') ? 'display-brightness-symbolic' : iconParam,
         });
+        if (iconParam.startsWith('/') && this._icon)
+            this._icon.gicon = Gio.FileIcon.new(Gio.File.new_for_path(iconParam));
         /* OSD is never shown by default */
         this._hideOSD = true;
         this.__hideOSDBackup = true;
@@ -424,7 +440,7 @@ export const SingleMonitorSliderAndValueForQuickSettings = GObject.registerClass
     }
 
     _SliderChange() {
-        brightnessLog(this._settings, `QuickSettings _SliderChange event ${this.ValueSlider.value}`) 
+        brightnessLog(this._settings, `QuickSettings _SliderChange event ${this.ValueSlider.value}`)
         sliderValueChangeCommon(this);
     }
 });

--- a/display-brightness-ddcutil@themightydeity.github.com/prefs.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/prefs.js
@@ -29,6 +29,7 @@ const PrefsWidget = GObject.registerClass({
         'vcp_code_list_expander',
         'vcp_code_row_6b',
         'vcp_code_row_10',
+        'vcp_code_row_12',
         'ddcutil_additional_args_row',
         'allow_zero_brightness_row',
         'disable_display_state_check_row',
@@ -115,6 +116,12 @@ const PrefsWidget = GObject.registerClass({
             Gio.SettingsBindFlags.DEFAULT
         );
         this.settings.bind(
+            'vcp-12',
+            this._vcp_code_row_12,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        this.settings.bind(
             'vcp-6b',
             this._vcp_code_row_6b,
             'active',
@@ -193,16 +200,18 @@ const PrefsWidget = GObject.registerClass({
         }
         return vcpList
     }
-    disableLastVCP(){
-        const vcpList = this.getVCPList()
+    disableLastVCP() {
+        const brightnessVcpList = this.getVCPList()
+
         this._vcp_code_row_6b.sensitive = true
         this._vcp_code_row_10.sensitive = true
-        if(vcpList.length == 1){
-            if(vcpList[0] == "10"){
+        this._vcp_code_row_12.sensitive = true
+
+        if (brightnessVcpList.length == 1) {
+            if (brightnessVcpList[0] == "10")
                 this._vcp_code_row_10.sensitive = false
-            }else{
+            else
                 this._vcp_code_row_6b.sensitive = false
-            }
         }
     }
     fixVCPInfoSubtitle(){
@@ -230,7 +239,7 @@ const PrefsWidget = GObject.registerClass({
                 disableSubMenu(_('Need to disable (Only "All" slider)'))
             }
         }
-    } 
+    }
     onButtonLocationChanged() {
         this.settings.set_int('button-location', this._button_location_combo_row.selected);
         if (this._button_location_combo_row.selected === 0) {

--- a/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
+++ b/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
@@ -79,6 +79,10 @@
       <default>true</default>
       <summary>Use VCP code 10</summary>
     </key>
+    <key type="b" name="vcp-12">
+      <default>false</default>
+      <summary>Use VCP code 12</summary>
+    </key>
     <key type="b" name="vcp-6b">
       <default>false</default>
       <summary>Use VCP code 6B</summary>

--- a/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
@@ -138,6 +138,12 @@
               </object>
             </child>
             <child>
+              <object class="AdwSwitchRow" id="vcp_code_row_12">
+                <property name="title">12</property>
+                <property name="subtitle" translatable="yes">Contrast</property>
+              </object>
+            </child>
+            <child>
               <object class="AdwSwitchRow" id="vcp_code_row_6b">
                 <property name="title">6B</property>
                 <property name="subtitle" translatable="yes">White Backlight</property>


### PR DESCRIPTION
Adds a separate contrast slider per monitor using VCP 12, independent of the brightness fallback chain (VCP 10/6B).
Bundled a contrast SVG icon because there is no default GNOME icon for contrast.