### PR TITLE
Add configurable idle dimming for external monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 Display Brightness Slider for Gnome Shell
 
+## Idle dimming
+
+The extension can temporarily lower the hardware brightness of all detected
+external displays after a configurable period of user inactivity. Each
+display's previous brightness is saved independently and restored on the first
+mouse or keyboard activity. Idle dimming is disabled by default; when enabled,
+it defaults to five minutes and can be configured from the extension preferences.
+
+Automatic dimming and restoration use DDC/CI, just like the extension's
+sliders. Internal displays are left to GNOME's built-in power management.
+
 ![screenshot](screenshot.jpg)
 
 - [Setup ddcutil](#setup-ddcutil)

--- a/display-brightness-ddcutil@themightydeity.github.com/convenienceExt.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/convenienceExt.js
@@ -1,4 +1,5 @@
 import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 
 export function isNullOrWhitespace(str) {
     return str === undefined || str === null || str.match(/^\s*$/) !== null;
@@ -19,26 +20,41 @@ export async function spawnWithCallback(settings, argv, callback) {
     try {
         const proc = Gio.Subprocess.new(argv, Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE);
 
-        await proc.communicate_utf8_async(null, null, async (proc, res)=>{
-            const [, stdout, stderr] = proc.communicate_utf8_finish(res);
-            if (proc.get_successful()) {
-                await callback(stdout);
-            } else {
-                /*
-                    errors from ddcutil (like monitor not found) were actually in stdout
-                    only the process return code was 1
-                */
-                if (stderr)
-                    await callback(stderr);
-                else if (stdout)
-                    await callback(stdout);
-                else 
-                    await callback("");
-            }
+        return await new Promise(resolve => {
+            let timeoutActive = true;
+            const timeoutId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 15, () => {
+                timeoutActive = false;
+                brightnessLog(settings, `Command timed out: ${argv.join(' ')}`);
+                proc.force_exit();
+                return GLib.SOURCE_REMOVE;
+            });
+            proc.communicate_utf8_async(null, null, async (proc, res) => {
+                let successful = false;
+                try {
+                    const [, stdout, stderr] = proc.communicate_utf8_finish(res);
+                    successful = proc.get_successful();
+                    /*
+                        errors from ddcutil (like monitor not found) were actually in stdout
+                        only the process return code was 1
+                    */
+                    await callback(successful ? stdout : stderr || stdout || "", successful);
+                } catch (e) {
+                    brightnessLog(settings, e);
+                } finally {
+                    if (timeoutActive)
+                        GLib.Source.remove(timeoutId);
+                    resolve(successful);
+                }
+            });
         });
-        
     } catch (e) {
         brightnessLog(settings, e);
+        try {
+            await callback("", false);
+        } catch (callbackError) {
+            brightnessLog(settings, callbackError);
+        }
+        return false;
     }
 }
 

--- a/display-brightness-ddcutil@themightydeity.github.com/extension.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/extension.js
@@ -55,7 +55,6 @@ const {
 const minBrightness = 1;
 let displays = null;
 let mainMenuButton = null;
-let writeCollection = null;
 let _reloadMenuWidgetsTimer = null;
 let _reloadExtensionTimer = null;
 let reloadingExtension = false;
@@ -85,19 +84,38 @@ const BrightnessInterface = loadInterfaceXML('org.gnome.Shell.Brightness');
 const BrightnessProxy = Gio.DBusProxy.makeProxyWrapper(BrightnessInterface);
 
 export default class DDCUtilBrightnessControlExtension extends Extension {
-    enable() {
+    async enable() {
+        if (this._disablePromise)
+            await this._disablePromise;
         this.settings = this.getSettings();
+        this._shellDisabling = false;
+        this._idleMonitor = null;
+        this._idlePollSourceId = 0;
+        this._idleDimmed = false;
+        this._idleBrightnessByBus = new Map();
+        this._idleRestorePromise = null;
+        this._idleRestoreRetryAt = 0;
+        this._suppressSliderWrites = new Set();
+        this._idleConfigGeneration = 0;
+        this._writeCollection = {};
+        this._tearingDown = false;
+        this._reloadPromise = null;
+        this._disablePromise = null;
         this.enableBrightnessControl();
     }
 
     disable() {
-        this.disableBrightnessControl();
-        this.settings = null;
+        this._shellDisabling = true;
+        this._disablePromise = this.disableBrightnessControl().finally(() => {
+            this.settings = null;
+        });
     }
 
     enableBrightnessControl() {
         displays = [];
-        writeCollection = {};
+        this._writeCollection = {};
+        this._teardownPromise = null;
+        this._tearingDown = false;
         if (this.settings.get_int('button-location') === 0) {
             brightnessLog(this.settings, 'Adding to panel');
             mainMenuButton = new StatusAreaBrightnessMenu(this.settings);
@@ -113,6 +131,7 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
             this.connectMonitorChangeSignals();
 
             this.addKeyboardShortcuts();
+            this.configureIdleDimming();
 
             if (this.settings.get_int('button-location') === 0) {
                 this.addTextItemToPanel(_('Initializing'));
@@ -124,6 +143,27 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
     }
 
     disableBrightnessControl() {
+        if (this._tearingDown)
+            return this._teardownPromise ?? Promise.resolve();
+        this._tearingDown = true;
+
+        this.removeIdleWatches();
+        this._idleConfigGeneration++;
+
+        /* Clear timers before any asynchronous restoration can yield. */
+        if (_reloadMenuWidgetsTimer) {
+            clearTimeout(_reloadMenuWidgetsTimer);
+            _reloadMenuWidgetsTimer = null;
+        }
+        if (_reloadExtensionTimer) {
+            clearTimeout(_reloadExtensionTimer);
+            _reloadExtensionTimer = null;
+        }
+        if (monitorChangeTimeout !== null) {
+            clearTimeout(monitorChangeTimeout);
+            monitorChangeTimeout = null;
+        }
+
         /* disconnect all signals */
         this.disconnectSettingsSignals();
         this.disconnectMonitorSignals();
@@ -131,68 +171,94 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
         /* remove shortcuts */
         this.removeKeyboardShortcuts();
 
-        /* clear timeouts */
-        if (_reloadMenuWidgetsTimer)
-            clearTimeout(_reloadMenuWidgetsTimer);
-
-        if (_reloadExtensionTimer)
-            clearTimeout(_reloadExtensionTimer);
-
-        Object.keys(writeCollection).forEach(bus => {
-            if (writeCollection[bus].interval !== null) {
-                clearInterval(writeCollection[bus].interval);
-            }
-        });
-        if (monitorChangeTimeout !== null) {
-            clearTimeout(monitorChangeTimeout)
-            monitorChangeTimeout = null;
-        }
-
-        /* clear variables */
+        /* Remove UI and module globals synchronously for GNOME Shell lifecycle safety. */
+        const teardownDisplays = displays;
         mainMenuButton.destroy();
         mainMenuButton = null;
         displays = null;
-        writeCollection = null;
+
+        /* Finish serialized restoration using only this instance's captured state. */
+        this._teardownPromise = (async () => {
+            await this.disableIdleDimming(true, teardownDisplays);
+            await this.waitForAllDdcWrites();
+            this._writeCollection = null;
+        })();
+        return this._teardownPromise;
     }
 
     ddcWriteCollector(displayBus, writer) {
-        const kickoffNext = (reason) => {
-            brightnessLog(this.settings, `kickoffNext called ${reason}`);
-            writeCollection[displayBus].current = writeCollection[displayBus].next;
-            writeCollection[displayBus].next = null;
-            if (writeCollection[displayBus].current) {
-                writeCollection[displayBus].current(() => {
-                    if (writeCollection === null) {
-                        // Must be disabling. Do nothing.
-                        return;
-                    }
-                    kickoffNext("on chain");
-                });
-            } else {
-                brightnessLog(this.settings, "writer done, nothing next");
-            }
-        }
+        if (this._writeCollection === null)
+            return Promise.resolve(false);
 
-        if (displayBus in writeCollection) {
-            writeCollection[displayBus].next = writer;
-            if (writeCollection[displayBus].current) {
-                brightnessLog(this.settings, "Saving writer for when ready");
-            } else {
-                kickoffNext("on start");
-            }
-            return;
-        }
-        writeCollection[displayBus] = {
-            next: writer,
-            current: null
-        };
-        kickoffNext("on start");
+        if (!(displayBus in this._writeCollection))
+            this._writeCollection[displayBus] = {current: null, next: null};
+
+        const entry = this._writeCollection[displayBus];
+        return new Promise(resolve => {
+            if (entry.next !== null)
+                entry.next.resolve(false);
+            let complete;
+            const completion = new Promise(completionResolve => {
+                complete = completionResolve;
+            });
+            entry.next = {
+                writer,
+                completion,
+                resolve: successful => {
+                    resolve(successful);
+                    complete();
+                },
+            };
+
+            if (entry.current !== null)
+                brightnessLog(this.settings, 'Saving writer for when ready');
+            else
+                this.runNextDdcWrite(displayBus);
+        });
     }
 
-    setBrightness(display, newValue) {
+    async runNextDdcWrite(displayBus) {
+        const entry = this._writeCollection?.[displayBus];
+        if (!entry || entry.current !== null || entry.next === null)
+            return;
+
+        entry.current = entry.next;
+        entry.next = null;
+        let successful = false;
+        try {
+            successful = await entry.current.writer();
+        } catch (error) {
+            brightnessLog(this.settings, error);
+        } finally {
+            entry.current.resolve(successful);
+            entry.current = null;
+            if (entry.next !== null)
+                this.runNextDdcWrite(displayBus);
+            else
+                brightnessLog(this.settings, 'writer done, nothing next');
+        }
+    }
+
+    async waitForAllDdcWrites() {
+        while (this._writeCollection !== null) {
+            const pending = Object.values(this._writeCollection).flatMap(entry =>
+                [entry.current, entry.next]
+                    .filter(item => item !== null)
+                    .map(item => item.completion)
+            );
+            if (pending.length === 0)
+                return;
+            await Promise.all(pending);
+        }
+    }
+
+    setBrightness(display, newValue, automatic = false) {
+        if (!automatic)
+            this.cancelIdleRestoreForBus(display.bus);
+
         if (display.bus === 'internal') {
             this.setInternalBrightness(newValue);
-            return;
+            return Promise.resolve(true);
         }
         let newBrightness = parseInt((newValue / 100) * display.max);
         if (newBrightness === 0) {
@@ -202,15 +268,181 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
         const ddcutilPath = this.settings.get_string('ddcutil-binary-path');
         const ddcutilAdditionalArgs = this.settings.get_string('ddcutil-additional-args');
         const sleepMultiplier = this.settings.get_double('ddcutil-sleep-multiplier') / 40;
-        const writer = async (ondone) => {
+        const writer = async () => {
             const cmd = `${ddcutilPath} setvcp ${display.vcp} ${newBrightness} --bus ${display.bus} --sleep-multiplier ${sleepMultiplier} ${ddcutilAdditionalArgs}`.split(" ").filter(x => x !== "");
             brightnessLog(this.settings, `async ${cmd.join(" ")}`);
-            await spawnWithCallback(this.settings, cmd, async (result) => {if (ondone) {await ondone();}});
+            return await spawnWithCallback(this.settings, cmd, () => {});
         };
         brightnessLog(this.settings, `display ${display.name}, current: ${display.current} => ${newValue / 100}, new brightness: ${newBrightness}, new value: ${newValue}`);
         display.current = newValue / 100;
 
-        this.ddcWriteCollector(display.bus, writer);
+        return this.ddcWriteCollector(display.bus, writer);
+    }
+
+    removeIdleWatches() {
+        if (this._idlePollSourceId !== 0) {
+            GLib.Source.remove(this._idlePollSourceId);
+            this._idlePollSourceId = 0;
+        }
+    }
+
+    cancelIdleRestoreForBus(displayBus) {
+        if (!this._idleDimmed || !this._idleBrightnessByBus.delete(displayBus))
+            return;
+
+        brightnessLog(this.settings, `User brightness change overrides idle restoration for bus ${displayBus}`);
+        if (this._idleBrightnessByBus.size === 0) {
+            this._idleDimmed = false;
+            this._idleRestoreRetryAt = 0;
+        }
+    }
+
+    configureIdleDimming() {
+        this.removeIdleWatches();
+        const generation = ++this._idleConfigGeneration;
+
+        if (!this.settings.get_boolean('idle-dimming-enabled')) {
+            brightnessLog(this.settings, 'Idle dimming disabled');
+            void this.disableIdleDimming(true).finally(() => {
+                if (generation === this._idleConfigGeneration)
+                    this._idleMonitor = null;
+            });
+            return;
+        }
+
+        try {
+            if (generation !== this._idleConfigGeneration)
+                return;
+            this._idleMonitor = global.backend.get_core_idle_monitor();
+            brightnessLog(this.settings, 'Idle dimming enabled');
+            this.scheduleIdleWatch();
+        } catch (error) {
+            brightnessLog(this.settings, `Unable to initialize idle dimming: ${error}`);
+            if (generation === this._idleConfigGeneration)
+                this._idleMonitor = null;
+        }
+    }
+
+    scheduleIdleWatch() {
+        if (this._idleMonitor === null || this._idlePollSourceId !== 0 ||
+            !this.settings.get_boolean('idle-dimming-enabled'))
+            return;
+
+        const activePollIntervalMs = 10000;
+        const dimmedPollIntervalMs = 500;
+        const pollIntervalMs = this._idleDimmed
+            ? dimmedPollIntervalMs
+            : activePollIntervalMs;
+        brightnessLog(this.settings, `Polling idle time again in ${pollIntervalMs} ms`);
+        this._idlePollSourceId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, pollIntervalMs, () => {
+            this._idlePollSourceId = 0;
+            const delayMs = this.settings.get_int('idle-dimming-delay-minutes') * 60 * 1000;
+            const idleTime = this._idleMonitor.get_idletime();
+            if (!this._idleDimmed && idleTime >= delayMs)
+                this.dimDisplaysForIdle();
+            else if (this._idleDimmed && idleTime < delayMs &&
+                GLib.get_monotonic_time() / 1000 >= this._idleRestoreRetryAt) {
+                void this.restoreIdleBrightness().finally(() => this.scheduleIdleWatch());
+                return GLib.SOURCE_REMOVE;
+            }
+
+            this.scheduleIdleWatch();
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
+    changeBrightnessAutomatically(display, brightness, updateSlider = true) {
+        if (display.slider && updateSlider) {
+            this._suppressSliderWrites.add(display.bus);
+            display.slider.setHideOSD();
+            try {
+                display.slider.changeValue(brightness);
+            } finally {
+                display.slider.resetOSD();
+                this._suppressSliderWrites.delete(display.bus);
+            }
+        }
+        return this.setBrightness(display, brightness, true);
+    }
+
+    dimDisplaysForIdle() {
+        if (this._idleDimmed || displays === null)
+            return;
+
+        const externalDisplays = displays.filter(display => display.bus !== 'internal');
+        this._idleBrightnessByBus.clear();
+        this._idleDimmed = true;
+
+        /* Late DDC discovery will dim displays in the discovery callback. */
+        if (externalDisplays.length === 0) {
+            brightnessLog(this.settings, 'Idle detected; waiting for display discovery');
+            return;
+        }
+
+        for (const display of externalDisplays)
+            this._idleBrightnessByBus.set(display.bus, display.current * 100);
+
+        const dimBrightness = this.settings.get_double('idle-dimming-brightness');
+        brightnessLog(this.settings, `Idle detected; dimming displays to ${dimBrightness}%`);
+        for (const display of externalDisplays)
+            void this.changeBrightnessAutomatically(display, dimBrightness);
+    }
+
+    restoreIdleBrightness(abandonMissing = false, availableDisplays = displays) {
+        if (this._idleRestorePromise !== null)
+            return this._idleRestorePromise;
+        this._idleRestorePromise = this._restoreIdleBrightness(abandonMissing, availableDisplays)
+            .finally(() => {
+                this._idleRestorePromise = null;
+            });
+        return this._idleRestorePromise;
+    }
+
+    async _restoreIdleBrightness(abandonMissing = false, availableDisplays = displays) {
+        if (!this._idleDimmed || availableDisplays === null)
+            return true;
+
+        brightnessLog(this.settings, 'User active; restoring display brightness');
+        const displaysByBus = new Map(availableDisplays.map(display => [display.bus, display]));
+        const restoreResults = await Promise.all(
+            [...this._idleBrightnessByBus.entries()].map(async ([bus, brightness]) => {
+                const display = displaysByBus.get(bus);
+                if (!display)
+                    return {bus, successful: false, missing: true};
+                const successful = await this.changeBrightnessAutomatically(
+                    display,
+                    brightness,
+                    !this._tearingDown
+                );
+                return {bus, successful, missing: false};
+            })
+        );
+
+        for (const {bus, successful, missing} of restoreResults) {
+            if (successful || (missing && abandonMissing))
+                this._idleBrightnessByBus.delete(bus);
+            if (missing && abandonMissing)
+                console.warn(`Unable to restore brightness for disconnected DDC bus ${bus}`);
+        }
+
+        if (this._idleBrightnessByBus.size === 0) {
+            this._idleDimmed = false;
+            this._idleRestoreRetryAt = 0;
+            return true;
+        }
+
+        this._idleRestoreRetryAt = GLib.get_monotonic_time() / 1000 + 10000;
+        return false;
+    }
+
+    async disableIdleDimming(abandonMissing = false, availableDisplays = displays) {
+        this.removeIdleWatches();
+        const restored = await this.restoreIdleBrightness(abandonMissing, availableDisplays);
+        if (!restored && abandonMissing) {
+            console.error(`Unable to restore idle brightness for DDC buses: ${[...this._idleBrightnessByBus.keys()].join(', ')}`);
+            this._idleBrightnessByBus.clear();
+            this._idleDimmed = false;
+        }
     }
 
     setInternalBrightness(newValue) {
@@ -332,7 +564,8 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
 
     addDisplayToPanel(display) {
         const onSliderChange = (quickSettingsSlider, newValue) => {
-            this.setBrightness(display, newValue);
+            if (!this._suppressSliderWrites.has(display.bus))
+                void this.setBrightness(display, newValue);
             this.syncAllSlider();
         };
         let displaySlider = null;
@@ -465,19 +698,29 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
        caused unecessary extra ddcutil calls.
      */
     reloadExtension() {
+        if (this._tearingDown || this._shellDisabling)
+            return;
         reloadingExtension = true;
         if (_reloadExtensionTimer)
             clearTimeout(_reloadExtensionTimer);
 
         _reloadExtensionTimer = setTimeout(() => {
             _reloadExtensionTimer = null;
-            this._reloadExtension();
+            if (this._reloadPromise !== null || this._shellDisabling)
+                return;
+            this._reloadPromise = this._reloadExtension()
+                .catch(error => console.error(error))
+                .finally(() => {
+                    this._reloadPromise = null;
+                });
         }, 1000);
     }
 
-    _reloadExtension() {
+    async _reloadExtension() {
         brightnessLog(this.settings, 'Reload extension');
-        this.disableBrightnessControl();
+        await this.disableBrightnessControl();
+        if (this._shellDisabling)
+            return;
         this.enableBrightnessControl();
         reloadingExtension = false;
     }
@@ -544,6 +787,15 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
         display = { 'bus': displayBus, 'max': maxBrightness, 'current': currentBrightness, 'name': displayName, 'vcp': vcp };
         brightnessLog(this.settings, `added display to list ${JSON.stringify(display)}`);
         displays.push(display);
+
+        /* Discovery can finish after the idle watch has already fired. */
+        if (this._idleDimmed) {
+            this._idleBrightnessByBus.set(display.bus, display.current * 100);
+            this.changeBrightnessAutomatically(
+                display,
+                this.settings.get_double('idle-dimming-brightness')
+            );
+        }
 
         /* cheap way of reloading all display slider in the panel */
         this.reloadMenuWidgets();
@@ -683,6 +935,9 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
             'ddcutil-binary-path': this.settings.get_string('ddcutil-binary-path'),
             'decrease-brightness-shortcut': this.settings.get_strv('decrease-brightness-shortcut'),
             'increase-brightness-shortcut': this.settings.get_strv('increase-brightness-shortcut'),
+            'idle-dimming-enabled': this.settings.get_boolean('idle-dimming-enabled'),
+            'idle-dimming-delay-minutes': this.settings.get_int('idle-dimming-delay-minutes'),
+            'idle-dimming-brightness': this.settings.get_double('idle-dimming-brightness'),
         };
         return out;
     }
@@ -745,6 +1000,12 @@ export default class DDCUtilBrightnessControlExtension extends Extension {
             }),
             verbose_debugging: this.settings.connect('changed::verbose-debugging', () => {
                 this.reloadExtension();
+            }),
+            idle_dimming_enabled: this.settings.connect('changed::idle-dimming-enabled', () => {
+                this.configureIdleDimming();
+            }),
+            idle_dimming_delay: this.settings.connect('changed::idle-dimming-delay-minutes', () => {
+                this.configureIdleDimming();
             }),
         };
     }

--- a/display-brightness-ddcutil@themightydeity.github.com/metadata.json
+++ b/display-brightness-ddcutil@themightydeity.github.com/metadata.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/daitj/gnome-display-brightness-ddcutil",
     "settings-schema": "org.gnome.shell.extensions.display-brightness-ddcutil",
     "gettext-domain": "display-brightness-ddcutil",
-    "version": 59,
+    "version": 60,
     "shell-version": [
         "49",
         "50"

--- a/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
+++ b/display-brightness-ddcutil@themightydeity.github.com/po/display-brightness-ddcutil.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-21 14:57+0200\n"
+"POT-Creation-Date: 2026-08-22 03:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -66,72 +66,102 @@ msgid "Position in System Menu"
 msgstr ""
 
 #: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:76
+msgid "Idle Dimming"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:77
+msgid ""
+"Temporarily lower external monitor backlights after user inactivity, then "
+"restore their previous values on activity."
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:80
+msgid "Enable Idle Dimming"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:85
+msgid "Dim After"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:86
+msgid "Minutes of inactivity"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:95
+msgid "Idle Brightness"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:96
+msgid "Percentage"
+msgstr ""
+
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:107
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:79
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:110
 msgid "Increase Brightness"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:89
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:120
 msgid "Decrease Brightness"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:99
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:130
 msgid "Step Change %"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:109
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:140
 msgid "Advanced Settings"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:112
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:143
 msgid "`ddcutil` Binary Path"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:118
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:149
 msgid "`ddcutil` Additional Arguments"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:124
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:155
 msgid "`ddcutil` Sleep Multiplier ms"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:132
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:163
 msgid "VCP codes in use"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:137
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:168
 msgid "Brightness"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:143
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:174
 msgid "White Backlight"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:150
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:181
 msgid "Allow Zero Brightness"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:155
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:186
 msgid "Disable Display State Check"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:156
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:187
 msgid ""
 "Disables the check for the display power state before changing brightness, "
 "might help in detecting more displays"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:161
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:192
 msgid "Verbose debugging"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:169
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:200
 msgid "Top Bar"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:170
+#: display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui:201
 msgid "System Menu"
 msgstr ""
 
@@ -152,24 +182,24 @@ msgstr ""
 msgid "Press Esc to cancel the keyboard shortcut."
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:118
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:123
 msgid "Initializing"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:289
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:402
 msgid "Settings"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:298
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:411
 msgid "Reload"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:315
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:319
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:428
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:432
 msgid "All"
 msgstr ""
 
-#: display-brightness-ddcutil@themightydeity.github.com/extension.js:588
+#: display-brightness-ddcutil@themightydeity.github.com/extension.js:710
 msgid "Internal"
 msgstr ""
 

--- a/display-brightness-ddcutil@themightydeity.github.com/prefs.js
+++ b/display-brightness-ddcutil@themightydeity.github.com/prefs.js
@@ -16,6 +16,9 @@ const PrefsWidget = GObject.registerClass({
         'show_value_label_row',
         'show_display_name_row',
         'show_osd_row',
+        'idle_dimming_enabled_row',
+        'idle_dimming_delay_row',
+        'idle_dimming_brightness_row',
         'button_location_combo_row',
         'sub_menu_row',
         'hide_system_indicator_row',
@@ -79,6 +82,15 @@ const PrefsWidget = GObject.registerClass({
             'active',
             Gio.SettingsBindFlags.DEFAULT
         );
+
+        this.settings.bind(
+            'idle-dimming-enabled',
+            this._idle_dimming_enabled_row,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        this._idle_dimming_delay_row.value = this.settings.get_int('idle-dimming-delay-minutes');
+        this._idle_dimming_brightness_row.value = this.settings.get_double('idle-dimming-brightness');
 
         this.settings.bind(
             'show-sliders-in-submenu',
@@ -267,6 +279,14 @@ const PrefsWidget = GObject.registerClass({
 
     onSleepMultiplierValueChanged() {
         this.settings.set_double('ddcutil-sleep-multiplier', this._sleep_multiplier_row.value);
+    }
+
+    onIdleDimmingDelayChanged() {
+        this.settings.set_int('idle-dimming-delay-minutes', this._idle_dimming_delay_row.value);
+    }
+
+    onIdleDimmingBrightnessChanged() {
+        this.settings.set_double('idle-dimming-brightness', this._idle_dimming_brightness_row.value);
     }
 }
 );

--- a/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
+++ b/display-brightness-ddcutil@themightydeity.github.com/schemas/org.gnome.shell.extensions.display-brightness-ddcutil.gschema.xml
@@ -30,6 +30,20 @@
       <default>true</default>
       <summary>Enables OSD</summary>
     </key>
+    <key type="b" name="idle-dimming-enabled">
+      <default>false</default>
+      <summary>Dim external displays after a period of user inactivity</summary>
+    </key>
+    <key type="i" name="idle-dimming-delay-minutes">
+      <range min="1" max="120" />
+      <default>5</default>
+      <summary>Minutes of inactivity before external displays are dimmed</summary>
+    </key>
+    <key type="d" name="idle-dimming-brightness">
+      <range min="1" max="100" />
+      <default>5</default>
+      <summary>External display brightness percentage while idle</summary>
+    </key>
     <key type="i" name="button-location">
       <default>0</default>
       <range min="0" max="1" />

--- a/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
+++ b/display-brightness-ddcutil@themightydeity.github.com/ui/prefs.ui
@@ -73,6 +73,37 @@
     </child>
     <child>
       <object class="AdwPreferencesGroup">
+        <property name="title" translatable="yes">Idle Dimming</property>
+        <property name="description" translatable="yes">Temporarily lower external monitor backlights after user inactivity, then restore their previous values on activity.</property>
+        <child>
+          <object class="AdwSwitchRow" id="idle_dimming_enabled_row">
+            <property name="title" translatable="yes">Enable Idle Dimming</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwSpinRow" id="idle_dimming_delay_row">
+            <property name="title" translatable="yes">Dim After</property>
+            <property name="subtitle" translatable="yes">Minutes of inactivity</property>
+            <property name="numeric">True</property>
+            <property name="adjustment">idle_dimming_delay_adjustment</property>
+            <property name="sensitive" bind-source="idle_dimming_enabled_row" bind-property="active" bind-flags="sync-create" />
+            <signal name="changed" handler="onIdleDimmingDelayChanged" swapped="no" />
+          </object>
+        </child>
+        <child>
+          <object class="AdwSpinRow" id="idle_dimming_brightness_row">
+            <property name="title" translatable="yes">Idle Brightness</property>
+            <property name="subtitle" translatable="yes">Percentage</property>
+            <property name="numeric">True</property>
+            <property name="adjustment">idle_dimming_brightness_adjustment</property>
+            <property name="sensitive" bind-source="idle_dimming_enabled_row" bind-property="active" bind-flags="sync-create" />
+            <signal name="changed" handler="onIdleDimmingBrightnessChanged" swapped="no" />
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwPreferencesGroup">
         <property name="title" translatable="yes">Keyboard Shortcuts</property>
         <child>
           <object class="AdwActionRow">
@@ -174,6 +205,16 @@
     <property name="lower">4</property>
     <property name="upper">200</property>
     <property name="step-increment">4</property>
+  </object>
+  <object class="GtkAdjustment" id="idle_dimming_delay_adjustment">
+    <property name="lower">1</property>
+    <property name="upper">120</property>
+    <property name="step-increment">1</property>
+  </object>
+  <object class="GtkAdjustment" id="idle_dimming_brightness_adjustment">
+    <property name="lower">1</property>
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="position_system_indicator_adjustment">
     <property name="lower">0</property>


### PR DESCRIPTION
Closes #130

## Summary

- add optional idle dimming for DDC-controlled external monitors
- save each monitor’s previous brightness independently and restore it on activity
- expose a 1–120 minute delay (five minutes by default) and configurable idle brightness (5% by default)
- suppress the brightness OSD for automatic changes
- preserve explicit user brightness changes made while waking from the dimmed state
- handle monitors discovered after the idle transition and perform a serialized best-effort restore when disabled

## Idle detection

During GNOME 50.4 testing, Meta.IdleMonitor.add_idle_watch() returned a valid watch ID, but its callback did not fire even after get_idletime() exceeded the configured threshold. This implementation polls Mutter’s authoritative idle counter every 10 seconds while active, then every 500 ms while dimmed for prompt restoration. The configured dim transition can therefore occur up to about 10 seconds after its minute boundary.

## DDC write safety

Per-bus writes remain coalesced but now expose completion results. Restoration is serialized behind any running write, failed restores retain their saved brightness for retry, subprocess creation failures always release the collector, and commands are bounded by a 15-second timeout. The Shell-facing disable path remains synchronous while any best-effort hardware restoration finishes on the isolated extension-instance queue.

## Testing

- live-tested the polling state machine with a 10-second development threshold on two DDC displays: both changed from 25% to 5%, then returned to 25% after pointer activity
- exercised subprocess success, nonzero exit, spawn failure, and timeout paths; every path released its completion callback
- verified schema compilation with glib-compile-schemas --strict
- validated preferences and schema XML with xmllint
- checked JavaScript syntax and built the GNOME extension bundle for the original upstream UUID